### PR TITLE
yoda: 1.3.1

### DIFF
--- a/yoda.rb
+++ b/yoda.rb
@@ -2,15 +2,15 @@ require 'formula'
 
 class Yoda < Formula
   homepage 'http://yoda.hepforge.org/'
-  url 'http://www.hepforge.org/archive/yoda/YODA-1.3.0.tar.gz'
-  sha1 'ef45b0cba2f807f2b6796959f00e6c1734ed1191'
+  url 'http://www.hepforge.org/archive/yoda/YODA-1.3.1.tar.gz'
+  sha1 'f752ef7898cb635f1bb6e9400bea515cca27b12f'
 
   head do
     url 'http://yoda.hepforge.org/hg/yoda', :using => :hg
 
-    depends_on :autoconf
-    depends_on :automake
-    depends_on :libtool
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
     depends_on 'cython' => :python
   end
 
@@ -29,6 +29,12 @@ class Yoda < Formula
     if build.with? 'root'
       args << "--enable-root"
       ENV.append "PYTHONPATH", Formula['root'].opt_prefix/"lib/root" if build.with? 'check'
+    end
+
+    unless build.head?
+      # prevent cython regeneration in YODA-1.3.1.tar.gz
+      touch 'pyext/yoda/.made_pyx_templates'
+      touch Dir.glob("pyext/yoda/*.{cpp,h}")
     end
 
     system "autoreconf", "-i" if build.head?


### PR DESCRIPTION
Hi there,

you are right that rivet wants yoda 1.3.1. So here it is.

Is there a more clever solution to line 22: `env :userpaths`? Without it, the cython executable symlinked into /usr/local/bin is not found during installation. Because cython is an external dependency, `depends_on` does not help here ..

Cheers
eno