### PR TITLE
topdrawer: new formula

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -25,6 +25,7 @@ env:
   - PACKAGE=sacrifice
   - PACKAGE=sherpa
   - PACKAGE=thepeg
+  - PACKAGE=topdrawer
   - PACKAGE=whizard
   - PACKAGE=yoda
 script:

--- a/README.md
+++ b/README.md
@@ -40,6 +40,7 @@ Thanks to [**braumeister.org**](http://braumeister.org/repos/davidchall/homebrew
 * `sacrifice`
 * `sherpa`
 * `thepeg`
+* `topdrawer`
 * `whizard`
 * `yoda`
 

--- a/herwig++.rb
+++ b/herwig++.rb
@@ -8,9 +8,9 @@ class Herwigxx < Formula
   head do
     url 'http://herwig.hepforge.org/hg/herwig', :using => :hg
 
-    depends_on :autoconf
-    depends_on :automake
-    depends_on :libtool
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
     depends_on 'gengetopt'
   end
 

--- a/lhapdf.rb
+++ b/lhapdf.rb
@@ -8,9 +8,9 @@ class Lhapdf < Formula
   head do
     url 'http://lhapdf.hepforge.org/hg/lhapdf', :using => :hg
 
-    depends_on :autoconf
-    depends_on :automake
-    depends_on :libtool
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
     depends_on 'cython' => :python
   end
 

--- a/rivet.rb
+++ b/rivet.rb
@@ -8,9 +8,9 @@ class Rivet < Formula
   head do
     url 'http://rivet.hepforge.org/hg/rivet', :using => :hg, :branch => 'tip'
 
-    depends_on :autoconf
-    depends_on :automake
-    depends_on :libtool
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
     depends_on 'cython' => :python
   end
 

--- a/sacrifice.rb
+++ b/sacrifice.rb
@@ -8,9 +8,9 @@ class Sacrifice < Formula
   head do
     url 'http://agile.hepforge.org/svn/contrib/Sacrifice', :using => :svn
 
-    depends_on :autoconf
-    depends_on :automake
-    depends_on :libtool
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
   end
 
   depends_on 'pythia8'

--- a/thepeg.rb
+++ b/thepeg.rb
@@ -8,9 +8,9 @@ class Thepeg < Formula
   head do
     url 'http://thepeg.hepforge.org/hg/ThePEG', :using => :hg
 
-    depends_on :autoconf
-    depends_on :automake
-    depends_on :libtool
+    depends_on "autoconf" => :build
+    depends_on "automake" => :build
+    depends_on "libtool" => :build
   end
 
   depends_on 'gsl'

--- a/topdrawer.rb
+++ b/topdrawer.rb
@@ -1,0 +1,41 @@
+class Topdrawer < Formula
+  homepage "http://ftp.riken.jp/iris/topdrawer/"
+  url "http://ftp.riken.jp/pub/iris/topdrawer/topdrawer.tar.gz"
+  version "1.4e"
+  sha256 "2a44dffd19e243aa261b4e3cd2b0fe6247ced97ee10e3271f8c7eeae8cb62401"
+
+  depends_on "homebrew/head-only/f2c" => :build
+  depends_on "gcc" => :build
+  depends_on "homebrew/x11/imake" => :build
+  depends_on "ugs" => :build
+  depends_on :x11
+
+  patch :p1 do
+    url "https://gist.githubusercontent.com/veprbl/80ced2fcd27dddf48d8e/raw/a5d474f7735221424ebcaa0ff03b6c36135b2d5a/topdrawer_OSX_fix.patch"
+    sha1 "daed4ea561bdbbc0d2f8fffc4773e294ed534909"
+  end
+
+  def install
+    ENV.deparallelize
+
+    inreplace "Imakefile.def", /^UGS = .+/, "UGS = #{Formula["ugs"].lib/"ugs.a"}"
+
+    system "xmkmf", "-a"
+    system "make", "clean"
+    system "make", "all"
+
+    bin.install "td"
+    share.install "examples"
+    share.install "doc"
+  end
+
+  test do
+    cd testpath do
+      system bin/"td", share/"examples/muon.top", "-d", "postscr"
+    end
+    # ouput filename is garbled due to some bug
+    ps_file = Dir[testpath/"*"].first
+    type = `file -b #{ps_file}`
+    assert_equal type.split.first, "PostScript"
+  end
+end

--- a/ugs.rb
+++ b/ugs.rb
@@ -1,0 +1,26 @@
+class Ugs < Formula
+  homepage "http://ftp.riken.jp/pub/iris/ugs/"
+  url "http://ftp.riken.jp/iris/ugs/ugs.tar.gz"
+  version "2.10e"
+  sha256 "27bc46e975917bdf149e9ff6997885ffa24b0b1416bdf82ffaea5246b36e1f83"
+
+  depends_on "homebrew/x11/imake" => :build
+  depends_on "gcc" => :build
+  depends_on :x11
+
+  patch :p1 do
+    url "https://gist.githubusercontent.com/veprbl/80ced2fcd27dddf48d8e/raw/38ac4ffeaf60a067b9753d91bafd859a3459a286/ugs_OSX_fix.patch"
+    sha1 "12ced3c791de9bcc9b50b1b0c75e12fdc700e604"
+  end
+
+  def install
+    ENV.deparallelize
+
+    system "xmkmf"
+    system "make", "Makefiles"
+    system "make", "clean"
+    system "make"
+
+    lib.install "ugs.a"
+  end
+end

--- a/whizard.rb
+++ b/whizard.rb
@@ -1,16 +1,14 @@
-require 'formula'
-
 class Whizard < Formula
-  homepage 'http://whizard.hepforge.org/'
-  url 'http://www.hepforge.org/archive/whizard/whizard-2.2.2.tar.gz'
-  sha1 'eaad01978aa01181fdeec9788f5b8114de5e1fb5'
+  homepage "http://whizard.hepforge.org/"
+  url "http://www.hepforge.org/archive/whizard/whizard-2.2.6.tar.gz"
+  sha256 "5f9bcedcdcf091be8c65bb2a0d6fc47bb8e32d97b8a23aed2d33c0fd1015d275"
 
   depends_on :fortran
-  depends_on 'objective-caml' => :recommended
-  depends_on 'fastjet' => :optional
-  depends_on 'hoppet' => :optional
-  depends_on 'hepmc' => :optional
-  depends_on 'lhapdf' => :optional
+  depends_on "objective-caml" => :recommended
+  depends_on "fastjet" => :optional
+  depends_on "hoppet" => :optional
+  depends_on "hepmc" => :optional
+  depends_on "lhapdf" => :optional
 
 
   def install
@@ -21,9 +19,9 @@ class Whizard < Formula
       --prefix=#{prefix}
     ]
 
-    args << "--disable-ocaml" if build.without? 'objective-caml'
-    args << "--enable-hoppet" if build.with? 'hoppet'
-    args << "--enable-fastjet" if build.with? 'fastjet'
+    args << "--disable-ocaml" if build.without? "objective-caml"
+    args << "--enable-hoppet" if build.with? "hoppet"
+    args << "--enable-fastjet" if build.with? "fastjet"
 
     system "./configure", *args
     system "make", "install"


### PR DESCRIPTION
There are different MC's that output their result in a TOPDRAWER format: MCFM, MadGraph5, different private codes.

The topdrawer software is rather old and there are newer scripts that try to support .top format[1][2]. But I think that it is just more pleasant to be able to see exactly what the MC author meant to show, so it's good to have the original software running.

This formula makes topdrawer compile on OSX 10.10, all features seem to work as expected including X11 display. The only bug I've encountered is that names of the generated postscript files are full of random invalid characters. I haven't figured where this is set to correct it.

I've figured that homebrew-hep would be better than homebrew-science or homebrew-x11 because I don't see why would anyone use topdrawer as a general purpose plotter and/or outside HEP.

This also introduces a separate formula for the UGS library. This is needed because homebrew doesn't support patches for resources and UGS needs patching.

[1] https://higgshunter.wordpress.com/2013/04/08/top2root/
[2] https://github.com/yannickulrich/topdrawer_mac