### PR TITLE
Formula fixes, rivet 2.4.0, nlojet++ formula

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -19,6 +19,7 @@ env:
   - PACKAGE=madgraph5_amcatnlo
   - PACKAGE=mcfm
   - PACKAGE=mcgrid
+  - PACKAGE=nlojet++
   - PACKAGE=pythia8
   - PACKAGE=qcdnum
   - PACKAGE=rivet

--- a/applgrid.rb
+++ b/applgrid.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Applgrid < Formula
   homepage 'http://applgrid.hepforge.org'
   url 'http://www.hepforge.org/archive/applgrid/applgrid-1.4.70.tgz'

--- a/applgrid.rb
+++ b/applgrid.rb
@@ -1,7 +1,7 @@
 class Applgrid < Formula
   homepage 'http://applgrid.hepforge.org'
   url 'http://www.hepforge.org/archive/applgrid/applgrid-1.4.70.tgz'
-  sha1 'bc63dd2fdaaeee6d04c1ed6c17c4fa7afd604814'
+  sha256 '37e191e0e8598b7ee486007733b99d39da081dd3411339da2468cb3d66e689fb'
 
   depends_on :fortran
   cxxstdlib_check :skip

--- a/fastjet.rb
+++ b/fastjet.rb
@@ -1,7 +1,7 @@
 class Fastjet < Formula
   homepage 'http://fastjet.fr/'
   url 'http://fastjet.fr/repo/fastjet-3.1.3.tar.gz'
-  sha1 '9df03475559f202e889a75c092a32a7dcd1dbd14'
+  sha256 '9809c2a0c89aec30890397d01eda56621e036589b66d7b3cd196cf087c65e40d'
 
   depends_on 'cgal' => :optional
   option 'with-cgal', 'Enable CGAL support (required for NlnN strategy)'

--- a/fastjet.rb
+++ b/fastjet.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Fastjet < Formula
   homepage 'http://fastjet.fr/'
   url 'http://fastjet.fr/repo/fastjet-3.1.3.tar.gz'

--- a/fastnlo.rb
+++ b/fastnlo.rb
@@ -1,7 +1,7 @@
 class Fastnlo < Formula
   homepage 'http://fastnlo.hepforge.org'
   url 'http://fastnlo.hepforge.org/code/v23/fastnlo_toolkit-2.3.1pre-1871.tar.gz'
-  sha1 'bf536b78c5bb5bc5568e546454fc9dcb87db6978'
+  sha256 '3336dfd42f88ac1574ee81724c36ce7593fd0de0ff7585c8e16706b5883b8c3e'
   version '2.3.1.1871'
 
   depends_on 'lhapdf'

--- a/fjcontrib.rb
+++ b/fjcontrib.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Fjcontrib < Formula
   homepage 'http://fastjet.hepforge.org/contrib/'
   url 'http://fastjet.hepforge.org/contrib/downloads/fjcontrib-1.018.tar.gz'

--- a/fjcontrib.rb
+++ b/fjcontrib.rb
@@ -1,7 +1,7 @@
 class Fjcontrib < Formula
   homepage 'http://fastjet.hepforge.org/contrib/'
   url 'http://fastjet.hepforge.org/contrib/downloads/fjcontrib-1.018.tar.gz'
-  sha1 'c63eaa6d561271df408f9e48969d9189ad3fa4c8'
+  sha256 'fe9d9661cefba048b19002abec7e75385ed73a8a3f45a29718e110beab142c2c'
 
   depends_on 'fastjet'
   option 'with-check', 'Test during installation'

--- a/hepmc.rb
+++ b/hepmc.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Hepmc < Formula
   homepage 'http://lcgapp.cern.ch/project/simu/HepMC/'
   url 'http://lcgapp.cern.ch/project/simu/HepMC/download/HepMC-2.06.09.tar.gz'
-  sha1 'ecb97190abedfe774629a1cbc961910b4d83b7d6'
+  sha256 'c60724ca9740230825e06c0c36fb2ffe17ff1b1465e8656268a61dffe1611a08'
 
   depends_on 'cmake' => :build
   option 'with-check', 'Test during installation'

--- a/herwig++.rb
+++ b/herwig++.rb
@@ -1,7 +1,7 @@
 class Herwigxx < Formula
   homepage 'http://herwig.hepforge.org/'
   url 'http://www.hepforge.org/archive/herwig/Herwig++-2.7.1.tar.gz'
-  sha1 '60c18beeb34f05ff4e4ae3fbf51f9935d58a0a0e'
+  sha256 'e935134b00184171feafffa173dd7a46184ee7d3628a98f7a7e8ba35cd87d90e'
 
   head do
     url 'http://herwig.hepforge.org/hg/herwig', :using => :hg

--- a/herwig++.rb
+++ b/herwig++.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Herwigxx < Formula
   homepage 'http://herwig.hepforge.org/'
   url 'http://www.hepforge.org/archive/herwig/Herwig++-2.7.1.tar.gz'

--- a/hoppet.rb
+++ b/hoppet.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Hoppet < Formula
   homepage 'http://hoppet.hepforge.org'
   url 'http://hoppet.hepforge.org/downloads/hoppet-1.1.5.tgz'

--- a/hoppet.rb
+++ b/hoppet.rb
@@ -1,7 +1,7 @@
 class Hoppet < Formula
   homepage 'http://hoppet.hepforge.org'
   url 'http://hoppet.hepforge.org/downloads/hoppet-1.1.5.tgz'
-  sha1 'd328f12eb027a53f5333c0d402ba5e6cd8c015d8'
+  sha256 '41872b2c7ea10344ebbe4260165c24236e17c3d4b14310724eb36577b9c19402'
 
   depends_on :fortran
   option 'with-check', 'Test during installation'

--- a/jetvheto.rb
+++ b/jetvheto.rb
@@ -1,7 +1,7 @@
 class Jetvheto < Formula
   homepage 'http://jetvheto.hepforge.org'
   url 'http://jetvheto.hepforge.org/downloads/JetVHeto-1.0.0.tgz'
-  sha1 'cb28ffacaab59722b25b75d9f2ec094339eeaf0d'
+  sha256 '1e9673439fa9df840e09c0cb94329d52b38e4b5ef49c6f5f6de2388f574cfa3e'
 
   depends_on 'hoppet'
   depends_on 'lhapdf'

--- a/lhapdf.rb
+++ b/lhapdf.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Lhapdf < Formula
   homepage 'http://lhapdf.hepforge.org/'
   url 'http://www.hepforge.org/archive/lhapdf/LHAPDF-6.1.5.tar.gz'

--- a/lhapdf.rb
+++ b/lhapdf.rb
@@ -1,7 +1,7 @@
 class Lhapdf < Formula
   homepage 'http://lhapdf.hepforge.org/'
   url 'http://www.hepforge.org/archive/lhapdf/LHAPDF-6.1.5.tar.gz'
-  sha1 '57bb1e1a97c89459320aa6e5cc3cfcf852b4c862'
+  sha256 'ee5dfac1c32a386c966b28cb6a2d51531d4eaf9945c4cb48431dd3fabef83231'
 
   head do
     url 'http://lhapdf.hepforge.org/hg/lhapdf', :using => :hg

--- a/madgraph5_amcatnlo.rb
+++ b/madgraph5_amcatnlo.rb
@@ -1,7 +1,7 @@
 class Madgraph5Amcatnlo < Formula
   homepage 'https://launchpad.net/mg5amcnlo'
   url 'https://launchpad.net/mg5amcnlo/2.0/2.2.0/+download/MG5_aMC_v2.2.3.tar.gz'
-  sha1 '0be13b50433e20c8b75bd31f9efa9e18df07220f'
+  sha256 '3dc45942d0213b22b32770eee559b1cf1d96a77c9e3db82cba3684b240265c99'
 
   depends_on 'fastjet'
   depends_on :fortran

--- a/madgraph5_amcatnlo.rb
+++ b/madgraph5_amcatnlo.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Madgraph5Amcatnlo < Formula
   homepage 'https://launchpad.net/mg5amcnlo'
   url 'https://launchpad.net/mg5amcnlo/2.0/2.2.0/+download/MG5_aMC_v2.2.3.tar.gz'

--- a/mcfm.rb
+++ b/mcfm.rb
@@ -1,7 +1,7 @@
 class Mcfm < Formula
   homepage 'http://mcfm.fnal.gov/'
   url 'http://mcfm.fnal.gov/MCFM-6.6.tar.gz'
-  sha1 'fb07546aa84c4e02ebd317242b1ee756097d493c'
+  sha256 '01ed9998eaac9a4e013e65dc844de4e5e0a491408a152d6ead004e536552b66a'
 
   keg_only "MCFM must be run from its install directory"
 

--- a/mcgrid.rb
+++ b/mcgrid.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Mcgrid < Formula
   homepage 'http://mcgrid.hepforge.org'
   url 'http://www.hepforge.org/archive/mcgrid/mcgrid-1.2.tar.gz'

--- a/mcgrid.rb
+++ b/mcgrid.rb
@@ -1,7 +1,7 @@
 class Mcgrid < Formula
   homepage 'http://mcgrid.hepforge.org'
   url 'http://www.hepforge.org/archive/mcgrid/mcgrid-1.2.tar.gz'
-  sha1 '23b5c4476aa85491eeaf42b67fc4a602ac7db6b5'
+  sha256 'd3956ca2b516c55c12a9065aa9789efbeab8791e9b6c96abeeb16c87f8925932'
 
   depends_on 'rivet'
   depends_on 'applgrid'
@@ -9,15 +9,15 @@ class Mcgrid < Formula
 
   resource 'examples-rivet200' do
     url 'http://www.hepforge.org/archive/mcgrid/MCgridExamples-2.0.0.tgz'
-    sha1 '53ecef3a3698e3c1056de64488356bb40418b362'
+    sha256 'c0abb1d1f2d816294eb3de4637107daab95d3494a08899a56bc548e6d72cca10'
   end
   resource 'examples-rivet212' do
     url 'http://www.hepforge.org/archive/mcgrid/MCgridExamples-2.1.2.tgz'
-    sha1 '3a68ff8d863d596c819f00c5a1053349ba565089'
+    sha256 '90c579aa5a0921a1fdd3260a85d2a92b229f80781718cce10bdaae96adde82ea'
   end
   resource 'examples-rivet220' do
     url 'http://www.hepforge.org/archive/mcgrid/MCgridExamples-2.2.0.tgz'
-    sha1 '89191a252fea9565cf7cd3d582ba7625fb73ab12'
+    sha256 'd772decaed3f7310948d1e6f84e553e80a95358a6bca7d7974d2b877b0f2475a'
   end
 
   def install

--- a/nlojet++.rb
+++ b/nlojet++.rb
@@ -1,0 +1,20 @@
+class Nlojetxx < Formula
+  homepage "http://www.desy.de/~znagy/Site/NLOJet++.html"
+  url "http://desy.de/~znagy/hep-programs/nlojet++/nlojet++-4.1.3.tar.gz"
+  sha256 "176d081bbc8c167cdd4516959cbcb2b9ba8f5515f503d29380deee2f67b10ea3"
+
+  patch :p1 do
+    url "https://gist.githubusercontent.com/veprbl/e404103016ba819d580b/raw/917c57e8cb47b025b8eef1cf6d74174540fb3ccd/nlojet_clang_fix.patch"
+    sha256 "4f7b10953b95b8568f10e7db674628f22e7198b158ed158e870a428b9f0b02d1"
+  end
+
+  def install
+    system "./configure", "--disable-dependency-tracking",
+                          "--prefix=#{prefix}"
+    system "make", "install"
+  end
+
+  test do
+    system bin/"nlojet++"
+  end
+end

--- a/pythia8.rb
+++ b/pythia8.rb
@@ -3,7 +3,7 @@ require 'formula'
 class Pythia8 < Formula
   homepage 'http://pythia8.hepforge.org'
   url 'http://home.thep.lu.se/~torbjorn/pythia8/pythia8186.tgz'
-  sha1 '6b9b58a8574ab406d947e01b0b200dee738e51ac'
+  sha256 '1c0914fc04801ee922c1ad3b544a3cd48b34d9afa4407ae40afbacd009039bd2'
   version '8.186'
 
   depends_on 'hepmc'

--- a/qcdnum.rb
+++ b/qcdnum.rb
@@ -1,6 +1,7 @@
 class Qcdnum < Formula
   homepage 'http://mbotje.web.cern.ch/mbotje/qcdnum'
-  url 'http://www.nikhef.nl/user/h24/qcdnum-files/download/qcdnum170006.tar.gz'
+  url 'https://www.hepforge.org/archive/qcdnum/qcdnum-17.00.06.tar.gz'
+  mirror 'http://www.nikhef.nl/user/h24/qcdnum-files/download/qcdnum170006.tar.gz'
   sha1 'e1917d8f3e211b9b516f254509e09a78985f0587'
   version '17.00.06'
 

--- a/qcdnum.rb
+++ b/qcdnum.rb
@@ -2,7 +2,7 @@ class Qcdnum < Formula
   homepage 'http://mbotje.web.cern.ch/mbotje/qcdnum'
   url 'https://www.hepforge.org/archive/qcdnum/qcdnum-17.00.06.tar.gz'
   mirror 'http://www.nikhef.nl/user/h24/qcdnum-files/download/qcdnum170006.tar.gz'
-  sha1 'e1917d8f3e211b9b516f254509e09a78985f0587'
+  sha256 'c454e8717631ce95180f517e0ddddc1aeeb30aa82eba75e555c39cc1cd4b2824'
   version '17.00.06'
 
   depends_on :fortran

--- a/qcdnum.rb
+++ b/qcdnum.rb
@@ -20,7 +20,7 @@ class Qcdnum < Formula
 
     LIBRARIES.each do |libname|
       cd libname do
-        system "#{ENV.fc} -c -Wall -O2 -Iinc */*.f"
+        system "#{ENV.fc} -c -fPIC -Wall -O2 -Iinc */*.f"
         system "ar -r #{lib}/lib#{libname}.a *.o"
       end
     end

--- a/rivet.rb
+++ b/rivet.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Rivet < Formula
   homepage 'http://rivet.hepforge.org/'
   url 'http://www.hepforge.org/archive/rivet/Rivet-2.3.0.tar.gz'

--- a/rivet.rb
+++ b/rivet.rb
@@ -1,7 +1,7 @@
 class Rivet < Formula
   homepage 'http://rivet.hepforge.org/'
-  url 'http://www.hepforge.org/archive/rivet/Rivet-2.3.0.tar.gz'
-  sha256 'f8a0806b7c87503e3f083c167991504c2056ab1a91960b3a2cf230611fc361e5'
+  url 'http://www.hepforge.org/archive/rivet/Rivet-2.4.0.tar.bz2'
+  sha256 '5ee2f34a277ed058b8aef750d946b40d4cf781023b9adab03ca95e803a39fb06'
 
   head do
     url 'http://rivet.hepforge.org/hg/rivet', :using => :hg, :branch => 'tip'

--- a/rivet.rb
+++ b/rivet.rb
@@ -1,7 +1,7 @@
 class Rivet < Formula
   homepage 'http://rivet.hepforge.org/'
   url 'http://www.hepforge.org/archive/rivet/Rivet-2.3.0.tar.gz'
-  sha1 '74d348579a70d7556136a7bb4dfae03d17a16450'
+  sha256 'f8a0806b7c87503e3f083c167991504c2056ab1a91960b3a2cf230611fc361e5'
 
   head do
     url 'http://rivet.hepforge.org/hg/rivet', :using => :hg, :branch => 'tip'

--- a/sacrifice.rb
+++ b/sacrifice.rb
@@ -1,7 +1,7 @@
 class Sacrifice < Formula
   homepage 'https://agile.hepforge.org/trac/wiki/Sacrifice'
   url 'http://www.hepforge.org/archive/agile/Sacrifice-0.9.9.tar.gz'
-  sha1 '3ce1ac020dea5c3b4505f6bf2de1e5c951cb4033'
+  sha256 'dc1630424a527fe4b3a2a92d5f740d7aec20cd79485ef87b14ed7ec6255df83f'
 
   head do
     url 'http://agile.hepforge.org/svn/contrib/Sacrifice', :using => :svn

--- a/sacrifice.rb
+++ b/sacrifice.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Sacrifice < Formula
   homepage 'https://agile.hepforge.org/trac/wiki/Sacrifice'
   url 'http://www.hepforge.org/archive/agile/Sacrifice-0.9.9.tar.gz'

--- a/sherpa.rb
+++ b/sherpa.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Sherpa < Formula
   homepage 'https://sherpa.hepforge.org/'
   url 'http://www.hepforge.org/archive/sherpa/SHERPA-MC-2.2.0.tar.gz'

--- a/thepeg.rb
+++ b/thepeg.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Thepeg < Formula
   homepage 'http://herwig.hepforge.org/'
   url 'http://www.hepforge.org/archive/thepeg/ThePEG-1.9.2.tar.gz'

--- a/thepeg.rb
+++ b/thepeg.rb
@@ -1,7 +1,7 @@
 class Thepeg < Formula
   homepage 'http://herwig.hepforge.org/'
   url 'http://www.hepforge.org/archive/thepeg/ThePEG-1.9.2.tar.gz'
-  sha1 'a5a09b90fb45e43c1e84ac55e4ee26b9bf4d55c5'
+  sha256 '67ad02c05bda877a338e59948c8314039f6152cc8228d881bd45edd12d1c1dc1'
 
   head do
     url 'http://thepeg.hepforge.org/hg/ThePEG', :using => :hg

--- a/whizard.rb
+++ b/whizard.rb
@@ -4,7 +4,7 @@ class Whizard < Formula
   sha256 "5f9bcedcdcf091be8c65bb2a0d6fc47bb8e32d97b8a23aed2d33c0fd1015d275"
 
   depends_on :fortran
-  depends_on "objective-caml" => :recommended
+  depends_on "ocaml" => :recommended
   depends_on "fastjet" => :optional
   depends_on "hoppet" => :optional
   depends_on "hepmc" => :optional

--- a/yoda.rb
+++ b/yoda.rb
@@ -1,5 +1,3 @@
-require 'formula'
-
 class Yoda < Formula
   homepage 'http://yoda.hepforge.org/'
   url 'http://www.hepforge.org/archive/yoda/YODA-1.5.2.tar.gz'

--- a/yoda.rb
+++ b/yoda.rb
@@ -1,7 +1,7 @@
 class Yoda < Formula
   homepage 'http://yoda.hepforge.org/'
   url 'http://www.hepforge.org/archive/yoda/YODA-1.5.2.tar.gz'
-  sha1 '34edcaf818d08a2513d82bb841eb91c6020bdf57'
+  sha256 '9e0360c0ffba06067a7796270b430fbb758cb12700d0d9d9652608eeb06650c0'
 
   head do
     url 'http://yoda.hepforge.org/hg/yoda', :using => :hg


### PR DESCRIPTION
First this makes introduces stylistic fixes to satisfy ```brew audit```
* removes old-style "require 'formula'" headers
* switches to use of sha256 checksums
* whizard: fix ocaml dependency name

Also I've discovered that official qcdnum v17.00.06 tarball was recently replaced with the one that uses autotools. Normally it would be a good thing, but this implementation combines what was previously four libraries into a single libqcdnum library and that breaks compilation for most of the existing software known to me. It seems that it would be best to (for now) preserve the old version of the tarball (take it from unaffected hepforge mirror for now). I've also contacted author for clarification.

Other thing is that rivet was updated to the latest stable version 2.4.0.

And, finally, a new formula for NLOJet++ is added. NLOJet++ is a LO and NLO jet cross section calculation software with support of e+e-, DIS, photoproduction and hadron-hadron processes.