### PR TITLE
rivet: provide explicit Boost path

### DIFF
--- a/rivet.rb
+++ b/rivet.rb
@@ -31,6 +31,7 @@ class Rivet < Formula
       --with-fastjet=#{Formula["fastjet"].prefix}
       --with-hepmc=#{Formula["hepmc"].prefix}
       --with-yoda=#{Formula["yoda"].prefix}
+      --with-boost=#{Formula["boost"].prefix}
     ]
 
     args << '--disable-analyses' if build.without? 'analyses'


### PR DESCRIPTION
I've discovered a memory leak that seems to be occurring on the systems with non-homebrew version of Boost installed (e.g. linux systems). The proposed change fixes the formula.