### PR TITLE
Update yoda.rb to v1.6.1

### DIFF
--- a/yoda.rb
+++ b/yoda.rb
@@ -1,7 +1,7 @@
 class Yoda < Formula
   homepage 'http://yoda.hepforge.org/'
-  url "http://www.hepforge.org/archive/yoda/YODA-1.5.9.tar.bz2"
-  sha256 "1a19cc8c34c08f1797a93d355250e682eb85d62d4ab277b6714d7873b4bdde75"
+  url "http://www.hepforge.org/archive/yoda/YODA-1.6.1.tar.gz"
+  sha256 "70daf67163567d0d9d24fcbca5e4b9f3eca8c359f118395b8d2d21c420fc06c6"
 
   head do
     url 'http://yoda.hepforge.org/hg/yoda', :using => :hg


### PR DESCRIPTION
This version requires the c++11 standard. Is supposed to be used for Rivet 2.5.X+ but the latest revision of Rivet (2.4.2) will work with this as well. Just needs the --enable-stdcxx11.