### PR TITLE
Update rivet.rb to v2.4.2

### DIFF
--- a/rivet.rb
+++ b/rivet.rb
@@ -1,7 +1,7 @@
 class Rivet < Formula
   homepage 'http://rivet.hepforge.org/'
-  url "http://www.hepforge.org/archive/rivet/Rivet-2.4.1.tar.bz2"
-  sha256 "c14f0f58d1792d84d62c62b44ebb94db004776feba83fd8186bba898d55123cf"
+  url "http://www.hepforge.org/archive/rivet/Rivet-2.4.2.tar.gz"
+  sha256 "8b994eb3358358fd304521f23cd080c5094cae60de46925ed3d9a5d5f6ab9953"
 
   head do
     url 'http://rivet.hepforge.org/hg/rivet', :using => :hg, :branch => 'tip'
@@ -17,7 +17,6 @@ class Rivet < Formula
   depends_on 'gsl'
   depends_on 'boost'
   depends_on 'yoda'
-  depends_on 'yaml-cpp'
   depends_on :python
   option 'with-check', 'Test during installation'
   option 'without-analyses', 'Do not build Rivet analyses'
@@ -27,6 +26,7 @@ class Rivet < Formula
     args = %W[
       --disable-debug
       --disable-dependency-tracking
+      --enable-stdcxx11
       --prefix=#{prefix}
       --with-fastjet=#{Formula["fastjet"].prefix}
       --with-hepmc=#{Formula["hepmc"].prefix}


### PR DESCRIPTION
Needs --enable-stdcxx11 when built again yoda 1.6.x+. Rivet 2.5.x+ with have this standard.