### PR TITLE
Update MCgrid to 2.0.1

### DIFF
--- a/applgrid.rb
+++ b/applgrid.rb
@@ -3,6 +3,7 @@ class Applgrid < Formula
   homepage "http://applgrid.hepforge.org"
   url "http://www.hepforge.org/archive/applgrid/applgrid-1.4.70.tgz"
   sha256 "37e191e0e8598b7ee486007733b99d39da081dd3411339da2468cb3d66e689fb"
+  patch :DATA
 
   depends_on :fortran
   cxxstdlib_check :skip
@@ -22,3 +23,43 @@ class Applgrid < Formula
     system "applgrid-config", "--version"
   end
 end
+__END__
+diff --git a/appl_grid/appl_grid.h b/appl_grid/appl_grid.h
+index 5059622..bcf5b67 100644
+--- a/appl_grid/appl_grid.h
++++ b/appl_grid/appl_grid.h
+@@ -56,7 +56,7 @@ public:
+   class exception : public std::exception { 
+   public:
+     exception(const std::string& s) { std::cerr << what() << " " << s << std::endl; }; 
+-    exception(std::ostream& s)      { std::cerr << what() << " " << s << std::endl; }; 
++    exception(std::ostream& s)      { std::cerr << std::endl; }; 
+     virtual const char* what() const throw() { return "appl::grid::exception"; }
+   };
+ 
+diff --git a/appl_grid/appl_pdf.h b/appl_grid/appl_pdf.h
+index c71fd84..5ac5abd 100644
+--- a/appl_grid/appl_pdf.h
++++ b/appl_grid/appl_pdf.h
+@@ -51,7 +51,7 @@ public:
+   class exception : public std::exception { 
+   public: 
+     exception(const std::string& s="") { std::cerr << what() << " " << s << std::endl; }; 
+-    exception(std::ostream& s)         { std::cerr << what() << " " << s << std::endl; }; 
++    exception(std::ostream& s)         { std::cerr << std::endl; }; 
+     const char* what() const throw() { return "appl::appl_pdf::exception "; }
+   };
+   
+diff --git a/src/appl_igrid.h b/src/appl_igrid.h
+index d25288e..a39fd46 100644
+--- a/src/appl_igrid.h
++++ b/src/appl_igrid.h
+@@ -52,7 +52,7 @@ private:
+   class exception { 
+   public:
+     exception(const std::string& s) { std::cerr << s << std::endl; }; 
+-    exception(std::ostream& s)      { std::cerr << s << std::endl; }; 
++    exception(std::ostream& s)      {}; 
+   };
+ 
+   typedef double (igrid::*transform_t)(double) const;

--- a/mcgrid.rb
+++ b/mcgrid.rb
@@ -1,8 +1,8 @@
 class Mcgrid < Formula
   desc "Projecting cross section calculations on grids"
   homepage "http://mcgrid.hepforge.org"
-  url "http://www.hepforge.org/archive/mcgrid/mcgrid-2.0.tar.gz"
-  sha256 "bb3568ef6376f3359bed7d79b8d1f66e48b2f012edb9f9137729b973c8c76d37"
+  url "http://www.hepforge.org/archive/mcgrid/mcgrid-2.0.1.tar.gz"
+  sha256 "aeb3fb5a1b5667819bf42e86b51fe9eaff0cf826736638043c634695a657f30f"
 
   depends_on "rivet"
   depends_on "applgrid" => :recommended


### PR DESCRIPTION
Updating the MCgrid formula to 2.0.1 (accounting for the Rivet update to C++11). This requires patching APPLgrid to remove compilation issues with C++11 (the developers of APPLgrid are aware of this). 