### PR TITLE
Build bottles on Travis-CI and deploy to Bintray

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -30,11 +30,16 @@ before_install:
 
 script:
   - brew tap davidchall/test-bot
-  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then brew test-bot --ci-pr; fi'
-  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then brew test-bot --ci-testing; fi'
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then
+      brew test-bot --ci-testing;
+    else
+      brew test-bot --ci-pr;
+    fi
 
 after_success:
-  - brew test-bot --ci-upload --git-name=davidchall --git-email=dhcrawley@gmail.com --bintray-org=davidchall
+  - if [ "$TRAVIS_BRANCH" = "master" ]; then
+      brew test-bot --ci-upload --git-name=davidchall --git-email=dhcrawley@gmail.com --bintray-org=davidchall;
+    fi
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ script:
     fi
 
 after_success:
-  - if [ "$TRAVIS_BRANCH" = "master" ]; then
+  - if [ "$TRAVIS_PULL_REQUEST" = "false" ] && [ "$TRAVIS_BRANCH" = "master" ]; then
       brew test-bot --ci-upload --git-name=davidchall --git-email=dhcrawley@gmail.com --bintray-org=davidchall;
     fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,8 +7,11 @@ cache:
 
 # https://docs.travis-ci.com/user/reference/osx/#OS-X-Version
 os: osx
-env: OSX=10.12
-osx_image: xcode8.3
+matrix:
+  include:
+    - osx_image: xcode9.1  # OSX 10.12
+    - osx_image: xcode8    # OSX 10.11
+    - osx_image: xcode6.4  # OSX 10.10
 
 before_install:
   - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,9 +9,12 @@ cache:
 os: osx
 matrix:
   include:
-    - osx_image: xcode9.1  # OSX 10.12
-    - osx_image: xcode8    # OSX 10.11
-    - osx_image: xcode6.4  # OSX 10.10
+    - osx_image: xcode9.1
+      env: OSX=10.12
+    - osx_image: xcode8
+      env: OSX=10.11
+    - osx_image: xcode6.4
+      env: OSX=10.10
 
 before_install:
   - export TRAVIS_COMMIT="$(git rev-parse --verify -q HEAD)"

--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,17 @@ before_install:
   - rm -rf "$HOMEBREW_TAP_DIR"
   - ln -s "$PWD" "$HOMEBREW_TAP_DIR"
   - export HOMEBREW_DEVELOPER="1"
+  - export HOMEBREW_BINTRAY_USER="davidchall"
+  - export HOMEBREW_BOTTLE_DOMAIN="https://dl.bintray.com/davidchall"
   - ulimit -n 1024
 
 script:
-  - brew test-bot
+  - brew tap davidchall/test-bot
+  - 'if [ "$TRAVIS_PULL_REQUEST" != "false" ]; then brew test-bot --ci-pr; fi'
+  - 'if [ "$TRAVIS_PULL_REQUEST" = "false" ]; then brew test-bot --ci-testing; fi'
+
+after_success:
+  - brew test-bot --ci-upload --git-name=davidchall --git-email=dhcrawley@gmail.com --bintray-org=davidchall
 
 notifications:
   email:

--- a/.travis.yml
+++ b/.travis.yml
@@ -25,7 +25,7 @@ before_install:
   - ln -s "$PWD" "$HOMEBREW_TAP_DIR"
   - export HOMEBREW_DEVELOPER="1"
   - export HOMEBREW_BINTRAY_USER="davidchall"
-  - export HOMEBREW_BOTTLE_DOMAIN="https://dl.bintray.com/davidchall"
+  - export TAP_BOTTLE_DOMAIN="https://dl.bintray.com/davidchall"
   - ulimit -n 1024
 
 script:

--- a/Formula/yoda.rb
+++ b/Formula/yoda.rb
@@ -1,7 +1,7 @@
 class Yoda < Formula
   desc "Yet more Objects for Data Analysis"
-  homepage "http://yoda.hepforge.org"
-  url "http://www.hepforge.org/archive/yoda/YODA-1.6.7.tar.gz"
+  homepage "https://yoda.hepforge.org"
+  url "https://www.hepforge.org/archive/yoda/YODA-1.6.7.tar.gz"
   sha256 "9fbdb8e9b2951ee6b984b2d5350b0a5a9c93c6f4a70c51dd77daa87336753cf6"
 
   head do
@@ -10,12 +10,11 @@ class Yoda < Formula
     depends_on "autoconf" => :build
     depends_on "automake" => :build
     depends_on "libtool" => :build
-    depends_on "cython" => :python
+    depends_on "cython" => :build
   end
 
   option "with-test", "Test during installation"
 
-  depends_on :python
   depends_on "root" => :optional
   depends_on "numpy" => :optional
   depends_on "homebrew/science/matplotlib" => :optional
@@ -42,6 +41,6 @@ class Yoda < Formula
   end
 
   test do
-    system "yoda-config", "--version"
+    system bin/"yoda-config", "--version"
   end
 end

--- a/Formula/yoda.rb
+++ b/Formula/yoda.rb
@@ -1,5 +1,4 @@
 class Yoda < Formula
-  # force change
   desc "Yet more Objects for Data Analysis"
   homepage "https://yoda.hepforge.org"
   url "https://www.hepforge.org/archive/yoda/YODA-1.6.7.tar.gz"

--- a/Formula/yoda.rb
+++ b/Formula/yoda.rb
@@ -1,5 +1,4 @@
 class Yoda < Formula
-  # force edit
   desc "Yet more Objects for Data Analysis"
   homepage "https://yoda.hepforge.org"
   url "https://www.hepforge.org/archive/yoda/YODA-1.6.7.tar.gz"

--- a/Formula/yoda.rb
+++ b/Formula/yoda.rb
@@ -1,4 +1,5 @@
 class Yoda < Formula
+  # force change
   desc "Yet more Objects for Data Analysis"
   homepage "https://yoda.hepforge.org"
   url "https://www.hepforge.org/archive/yoda/YODA-1.6.7.tar.gz"

--- a/Formula/yoda.rb
+++ b/Formula/yoda.rb
@@ -1,4 +1,5 @@
 class Yoda < Formula
+  # force edit
   desc "Yet more Objects for Data Analysis"
   homepage "https://yoda.hepforge.org"
   url "https://www.hepforge.org/archive/yoda/YODA-1.6.7.tar.gz"


### PR DESCRIPTION
The aim is to use Travis-CI to build bottles for this tap's formulae, and then upload them to my [Bintray](https://bintray.com/davidchall/homebrew-hep).

@MikeMcQuaid seems keen for this functionality in https://github.com/Homebrew/brew/issues/2572 and https://github.com/cartr/qt4-autobottler/issues/1. This would be helpful for other tap maintainers, and might be incorporated into [`brew tap-new`](https://github.com/Homebrew/brew/blob/master/Library/Homebrew/dev-cmd/tap-new.rb).

I believe I can do this using `brew test-bot` and `brew test-bot --ci-upload` if the right environment variables are set and arguments are passed. Some changes to [`brew test-bot`](https://github.com/Homebrew/homebrew-test-bot/blob/master/cmd/brew-test-bot.rb) might be required.

Notes:
- I set `HOMEBREW_BINTRAY_KEY` using encrypted Travis-CI variables