### PR TITLE
Option for python3 bindings for LHAPDF when building from source

### DIFF
--- a/Formula/lhapdf.rb
+++ b/Formula/lhapdf.rb
@@ -26,8 +26,8 @@ class Lhapdf < Formula
   def install
     ENV.cxx11
     inreplace "wrappers/python/setup.py.in", "stdc++", "c++" if ENV.compiler == :clang
-    inreplace "bin/lhapdf.in", "/usr/bin/env python", "/usr/bin/env python3" if build.with?("python3") 
-    inreplace "configure.ac", "AC_PATH_PROG(PYTHON, python)", "AC_PATH_PROG(PYTHON, python3)" if build.with?("python3") 
+    inreplace "bin/lhapdf.in", "/usr/bin/env python", "/usr/bin/env python3" if build.with?("python3")
+    inreplace "configure.ac", "AC_PATH_PROG(PYTHON, python)", "AC_PATH_PROG(PYTHON, python3)" if build.with?("python3")
 
     args = %W[
       --disable-debug
@@ -35,7 +35,7 @@ class Lhapdf < Formula
       --prefix=#{prefix}
     ]
 
-    system "autoreconf", "-i" if build.head? or build.with?("python3")
+    system "autoreconf", "-i" if build.head? || build.with?("python3")
     system "./configure", *args
     system "make"
     system "make", "install"
@@ -55,9 +55,9 @@ class Lhapdf < Formula
   test do
     system "#{bin}/lhapdf", "help"
     if build.with?("python3")
-        system "python3", "-c", "import lhapdf; lhapdf.version()"
+      system "python3", "-c", "import lhapdf; lhapdf.version()"
     else
-        system "python", "-c", "import lhapdf; lhapdf.version()"
+      system "python", "-c", "import lhapdf; lhapdf.version()"
     end
   end
 end


### PR DESCRIPTION
It's sometimes useful to have the lhapdf bindings available in python3. LHAPDF makes this a bit awkward by ignoring the `$PYTHON` environmental variable. The simplest way I could come up with of fixing this is just performing an inreplace of the definition of `$PYTHON` in configure.ac from `python` to `python3`. It seems to work for me but might not be the most elegant solution.

### Have you:

- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Checked that the tests still pass?
