### PR TITLE
<<-EOS.undent is disabled

### DIFF
--- a/Formula/lhapdf.rb
+++ b/Formula/lhapdf.rb
@@ -38,7 +38,7 @@ class Lhapdf < Formula
     system "make", "install"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     PDFs may be downloaded and installed with
 
       lhapdf install CT10nlo


### PR DESCRIPTION
Following Homebrew's error message:

Error: Calling <<-EOS.undent is disabled!
Use <<~EOS instead.
/usr/local/Homebrew/Library/Taps/davidchall/homebrew-hep/Formula/lhapdf.rb:49:in `caveats'
Please report this to the davidchall/hep tap!
Or, even better, submit a PR to fix it!

### Have you:

- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ ] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [ ] Checked that the tests still pass?
