### PR TITLE
Resolve "Fix broken Travis checks by addressing all brew-audit errors"

### DIFF
--- a/Formula/applgrid.rb
+++ b/Formula/applgrid.rb
@@ -10,7 +10,6 @@ class Applgrid < Formula
   depends_on "lhapdf" => :optional
 
   cxxstdlib_check :skip
-  #patch :DATA
 
   def install
     ENV.deparallelize
@@ -20,46 +19,6 @@ class Applgrid < Formula
   end
 
   test do
-    system "applgrid-config", "--version"
+    system "#{bin}/applgrid-config", "--version"
   end
 end
-__END__
-diff --git a/appl_grid/appl_grid.h b/appl_grid/appl_grid.h
-index 5059622..bcf5b67 100644
---- a/appl_grid/appl_grid.h
-+++ b/appl_grid/appl_grid.h
-@@ -56,7 +56,7 @@ public:
-   class exception : public std::exception { 
-   public:
-     exception(const std::string& s) { std::cerr << what() << " " << s << std::endl; }; 
--    exception(std::ostream& s)      { std::cerr << what() << " " << s << std::endl; }; 
-+    exception(std::ostream& s)      { std::cerr << std::endl; }; 
-     virtual const char* what() const throw() { return "appl::grid::exception"; }
-   };
- 
-diff --git a/appl_grid/appl_pdf.h b/appl_grid/appl_pdf.h
-index c71fd84..5ac5abd 100644
---- a/appl_grid/appl_pdf.h
-+++ b/appl_grid/appl_pdf.h
-@@ -51,7 +51,7 @@ public:
-   class exception : public std::exception { 
-   public: 
-     exception(const std::string& s="") { std::cerr << what() << " " << s << std::endl; }; 
--    exception(std::ostream& s)         { std::cerr << what() << " " << s << std::endl; }; 
-+    exception(std::ostream& s)         { std::cerr << std::endl; }; 
-     const char* what() const throw() { return "appl::appl_pdf::exception "; }
-   };
-   
-diff --git a/src/appl_igrid.h b/src/appl_igrid.h
-index d25288e..a39fd46 100644
---- a/src/appl_igrid.h
-+++ b/src/appl_igrid.h
-@@ -52,7 +52,7 @@ private:
-   class exception { 
-   public:
-     exception(const std::string& s) { std::cerr << s << std::endl; }; 
--    exception(std::ostream& s)      { std::cerr << s << std::endl; }; 
-+    exception(std::ostream& s)      {}; 
-   };
- 
-   typedef double (igrid::*transform_t)(double) const;

--- a/Formula/applgrid.rb
+++ b/Formula/applgrid.rb
@@ -1,7 +1,7 @@
 class Applgrid < Formula
   desc "Quickly reproduce NLO calculations with any input PDFs"
-  homepage "http://applgrid.hepforge.org"
-  url "http://www.hepforge.org/archive/applgrid/applgrid-1.4.70.tgz"
+  homepage "https://applgrid.hepforge.org"
+  url "https://www.hepforge.org/archive/applgrid/applgrid-1.4.70.tgz"
   sha256 "37e191e0e8598b7ee486007733b99d39da081dd3411339da2468cb3d66e689fb"
 
   depends_on "gcc" # for gfortran

--- a/Formula/applgrid.rb
+++ b/Formula/applgrid.rb
@@ -1,8 +1,8 @@
 class Applgrid < Formula
   desc "Quickly reproduce NLO calculations with any input PDFs"
   homepage "https://applgrid.hepforge.org"
-  url "https://www.hepforge.org/archive/applgrid/applgrid-1.4.70.tgz"
-  sha256 "37e191e0e8598b7ee486007733b99d39da081dd3411339da2468cb3d66e689fb"
+  url "https://www.hepforge.org/archive/applgrid/applgrid-1.5.15.tgz"
+  sha256 "87747fc66318777483e200015b45768d0c8d81f7df6ddc0c70928996ff58d3af"
 
   depends_on "gcc" # for gfortran
   depends_on "root"
@@ -10,10 +10,10 @@ class Applgrid < Formula
   depends_on "lhapdf" => :optional
 
   cxxstdlib_check :skip
-  patch :DATA
+  #patch :DATA
 
   def install
-    ENV.j1
+    ENV.deparallelize
 
     system "./configure", "--disable-dependency-tracking", "--prefix=#{prefix}"
     system "make", "install"

--- a/Formula/applgrid.rb
+++ b/Formula/applgrid.rb
@@ -3,14 +3,14 @@ class Applgrid < Formula
   homepage "http://applgrid.hepforge.org"
   url "http://www.hepforge.org/archive/applgrid/applgrid-1.4.70.tgz"
   sha256 "37e191e0e8598b7ee486007733b99d39da081dd3411339da2468cb3d66e689fb"
-  patch :DATA
 
   depends_on "gcc" # for gfortran
-  cxxstdlib_check :skip
-
-  depends_on "homebrew/science/root"
+  depends_on "root"
   depends_on "hoppet" => :recommended
   depends_on "lhapdf" => :optional
+
+  cxxstdlib_check :skip
+  patch :DATA
 
   def install
     ENV.j1

--- a/Formula/fastjet.rb
+++ b/Formula/fastjet.rb
@@ -1,8 +1,8 @@
 class Fastjet < Formula
   desc "Package for jet finding in pp and ee collisions"
   homepage "http://fastjet.fr"
-  url "http://fastjet.fr/repo/fastjet-3.3.0.tar.gz"
-  sha256 "e9da5b9840cbbec6d05c9223f73c97af1d955c166826638e0255706a6b2da70f"
+  url "http://fastjet.fr/repo/fastjet-3.3.2.tar.gz"
+  sha256 "3f59af13bfc54182c6bb0b0a6a8541b409c6fda5d105f17e03c4cce8db9963c2"
 
   bottle do
     root_url "https://dl.bintray.com/davidchall/bottles-hep"

--- a/Formula/fastnlo.rb
+++ b/Formula/fastnlo.rb
@@ -1,7 +1,7 @@
 class Fastnlo < Formula
   desc "Fast pQCD calculations for PDF fits"
-  homepage "http://fastnlo.hepforge.org"
-  url "http://fastnlo.hepforge.org/code/v23/fastnlo_toolkit-2.3.1pre-2212.tar.gz"
+  homepage "https://fastnlo.hepforge.org"
+  url "https://fastnlo.hepforge.org/code/v23/fastnlo_toolkit-2.3.1pre-2212.tar.gz"
   version "2.3.1.2212"
   sha256 "f7d16524db1e18cd5ee5fb493f0872ae4dc4a448e758d8ccdf5c090018b7f675"
 

--- a/Formula/fastnlo.rb
+++ b/Formula/fastnlo.rb
@@ -8,10 +8,10 @@ class Fastnlo < Formula
   depends_on "lhapdf"
   depends_on "fastjet" => :optional
   depends_on "hoppet"  => :optional
-  depends_on "qcdnum"  => :optional
-  depends_on "yoda"    => :optional
-  depends_on "homebrew/science/root" => :optional
   depends_on "python"  => :optional
+  depends_on "qcdnum"  => :optional
+  depends_on "root"    => :optional
+  depends_on "yoda"    => :optional
 
   def am_opt(pkg)
     (build.with? pkg) ? "--with-#{pkg}=#{Formula[pkg].opt_prefix}" : "--without-#{pkg}"

--- a/Formula/fjcontrib.rb
+++ b/Formula/fjcontrib.rb
@@ -1,8 +1,8 @@
 class Fjcontrib < Formula
   desc "Package of contributed add-ons to FastJet"
   homepage "https://fastjet.hepforge.org/contrib/"
-  url "https://fastjet.hepforge.org/contrib/downloads/fjcontrib-1.030.tar.gz"
-  sha256 "e4c47bf808f2c078d6fe332ccff00716fdec618e10b7adbf9344e44c8364dba9"
+  url "https://fastjet.hepforge.org/contrib/downloads/fjcontrib-1.041.tar.gz"
+  sha256 "31e244728de7787a582479cbed606a1c2fe5fcf3ad3ba1b0134742de5107510c"
 
   option "with-test", "Test during installation"
 

--- a/Formula/herwig.rb
+++ b/Formula/herwig.rb
@@ -15,14 +15,15 @@ class Herwig < Formula
 
   option "with-test", "Test during installation"
 
-  depends_on "thepeg"
-  depends_on "hepmc"
   depends_on "boost"
+  depends_on "gcc" # for gfortran
   depends_on "gsl"
+  depends_on "hepmc"
+  depends_on "thepeg"
   depends_on "madgraph5_amcatnlo" => :optional
   depends_on "openloops" => :optional
   depends_on "vbfnlo" => :optional
-  depends_on "gcc" # for gfortran
+
   cxxstdlib_check :skip
 
   def download_pdfs(dest, pdfs)

--- a/Formula/hoppet.rb
+++ b/Formula/hoppet.rb
@@ -1,7 +1,7 @@
 class Hoppet < Formula
   desc "QCD DGLAP evolution"
-  homepage "http://hoppet.hepforge.org"
-  url "http://hoppet.hepforge.org/downloads/hoppet-1.1.5.tgz"
+  homepage "https://hoppet.hepforge.org"
+  url "https://hoppet.hepforge.org/downloads/hoppet-1.1.5.tgz"
   sha256 "41872b2c7ea10344ebbe4260165c24236e17c3d4b14310724eb36577b9c19402"
 
   option "with-test", "Test during installation"

--- a/Formula/hoppet.rb
+++ b/Formula/hoppet.rb
@@ -16,6 +16,6 @@ class Hoppet < Formula
   end
 
   test do
-    system "hoppet-config", "--libs"
+    system "#{bin}/hoppet-config", "--libs"
   end
 end

--- a/Formula/jetvheto.rb
+++ b/Formula/jetvheto.rb
@@ -23,7 +23,7 @@ class Jetvheto < Formula
     cp "#{share}/fixed-order/H125-LHC8-R04-xmur050-xmuf050-log.fxd", "input.fxd"
     inreplace "input.fxd", "MSTW2008nnlo90cl.LHgrid", "MSTW2008nnlo68cl"
 
-    system "jetvheto", "-in", "input.fxd", "-out", "output.res", "-xQ", "0.05"
+    system "#{bin}/jetvheto", "-in", "input.fxd", "-out", "output.res", "-xQ", "0.05"
     ohai "Successfully resummed logs for H production at the LHC"
   end
 end

--- a/Formula/jetvheto.rb
+++ b/Formula/jetvheto.rb
@@ -1,7 +1,7 @@
 class Jetvheto < Formula
   desc "NNLL resummation for jet-veto efficiencies and cross sections"
-  homepage "http://jetvheto.hepforge.org"
-  url "http://jetvheto.hepforge.org/downloads/JetVHeto-1.0.0.tgz"
+  homepage "https://jetvheto.hepforge.org"
+  url "https://jetvheto.hepforge.org/downloads/JetVHeto-1.0.0.tgz"
   sha256 "1e9673439fa9df840e09c0cb94329d52b38e4b5ef49c6f5f6de2388f574cfa3e"
 
   depends_on "hoppet"

--- a/Formula/lhapdf.rb
+++ b/Formula/lhapdf.rb
@@ -20,8 +20,6 @@ class Lhapdf < Formula
     depends_on "cython" => :build
   end
 
-  needs :cxx11
-
   def install
     ENV.cxx11
     inreplace "wrappers/python/setup.py.in", "stdc++", "c++" if ENV.compiler == :clang

--- a/Formula/lhapdf.rb
+++ b/Formula/lhapdf.rb
@@ -16,8 +16,8 @@ class Lhapdf < Formula
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
-    depends_on "libtool" => :build
     depends_on "cython" => :build
+    depends_on "libtool" => :build
   end
 
   def install

--- a/Formula/lhapdf.rb
+++ b/Formula/lhapdf.rb
@@ -44,7 +44,7 @@ class Lhapdf < Formula
     At runtime, LHAPDF searches #{share}/LHAPDF
     and paths in LHAPDF_DATA_PATH for PDF sets.
 
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/lhapdf.rb
+++ b/Formula/lhapdf.rb
@@ -36,7 +36,7 @@ class Lhapdf < Formula
     system "make", "install"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     PDFs may be downloaded and installed with
 
       lhapdf install CT10nlo

--- a/Formula/madgraph5_amcatnlo.rb
+++ b/Formula/madgraph5_amcatnlo.rb
@@ -24,7 +24,7 @@ class Madgraph5Amcatnlo < Formula
     Dir["**/"].reverse_each { |d| touch prefix/d/".keepthisdir" if Dir.entries(d).sort==%w[. ..] }
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     To shower aMC@NLO events with herwig++ or pythia8, first install
     them via homebrew and then enter in the mg5_aMC interpreter:
 

--- a/Formula/madgraph5_amcatnlo.rb
+++ b/Formula/madgraph5_amcatnlo.rb
@@ -1,8 +1,8 @@
 class Madgraph5Amcatnlo < Formula
   desc "Automated LO and NLO processes matched to parton showers"
   homepage "https://launchpad.net/mg5amcnlo"
-  url "https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.0.tar.gz"
-  sha256 "ba182a2d85733b3652afa87802adee60bf6a5270cc260cdb38366ada5e8afef4"
+  url "https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.4.tar.gz"
+  sha256 "ec7f13018433888319536adba436012fca4a2ccb715b2f525c7efa5e870e7605"
 
   bottle :unneeded
 

--- a/Formula/madgraph5_amcatnlo.rb
+++ b/Formula/madgraph5_amcatnlo.rb
@@ -33,7 +33,7 @@ class Madgraph5Amcatnlo < Formula
       set hwpp_path #{HOMEBREW_PREFIX}
       set pythia8_path #{HOMEBREW_PREFIX}
 
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mcfm.rb
+++ b/Formula/mcfm.rb
@@ -43,7 +43,7 @@ class Mcfm < Formula
     must be symlinked to bin/PDFsets for MCFM to run.
     The default LHAPDF data path is symlinked by default.
 
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mcfm.rb
+++ b/Formula/mcfm.rb
@@ -36,7 +36,7 @@ class Mcfm < Formula
     pkgshare.install_symlink "#{Formula["lhapdf"].opt_share}/lhapdf/PDFsets" if build.with? "lhapdf"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     Running MCFM requires files found in #{pkgshare}
 
     If using LHAPDF for PDF sets, the PDF data directory

--- a/Formula/mcfm.rb
+++ b/Formula/mcfm.rb
@@ -5,10 +5,9 @@ class Mcfm < Formula
   sha256 "6533a51a93bf97c967bf3bd8d530934c8eb94c84978be1e1f9a9d71319c80cc3"
 
   option "with-openmp", "Enable OpenMP multithreading"
-  needs :openmp if build.with? "openmp"
 
-  depends_on "lhapdf" => :optional
   depends_on "gcc" # for gfortran
+  depends_on "lhapdf" => :optional
 
   def install
     if build.with? "openmp"

--- a/Formula/mcgrid.rb
+++ b/Formula/mcgrid.rb
@@ -38,7 +38,7 @@ class Mcgrid < Formula
     prefix.install resource("manual")
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     You can disable one of the applgrid and fastnlo dependencies.
     However, the build will fail if you disable both.
 

--- a/Formula/mcgrid.rb
+++ b/Formula/mcgrid.rb
@@ -1,7 +1,7 @@
 class Mcgrid < Formula
   desc "Projecting cross section calculations on grids"
-  homepage "http://mcgrid.hepforge.org"
-  url "http://www.hepforge.org/archive/mcgrid/mcgrid-2.0.2.tar.gz"
+  homepage "https://mcgrid.hepforge.org"
+  url "https://www.hepforge.org/archive/mcgrid/mcgrid-2.0.2.tar.gz"
   sha256 "deed9f6027b075a4d0e2128adb2c13b16ca5736c43426d9a85ac2dfc4f1788d7"
 
   depends_on "pkg-config" => :build
@@ -10,12 +10,12 @@ class Mcgrid < Formula
   depends_on "fastnlo" => :recommended
 
   resource "examples-rivet220" do
-    url "http://www.hepforge.org/archive/mcgrid/MCgrid2Examples-2.2.0.tar.gz"
+    url "https://www.hepforge.org/archive/mcgrid/MCgrid2Examples-2.2.0.tar.gz"
     sha256 "e2f8aac995876a5f2ec3f9d21aa054cbd7a5e7d3b621d12cb8a2afdd08663a31"
   end
 
   resource "manual" do
-    url "http://www.hepforge.org/archive/mcgrid/manual-2.0.0.pdf"
+    url "https://www.hepforge.org/archive/mcgrid/manual-2.0.0.pdf"
     sha256 "78ac032c459d26239329fb12560c7d33f6efbdf52d9d3ec606eee24de1f44326"
   end
 
@@ -47,7 +47,7 @@ class Mcgrid < Formula
 
     Examples are installed in:
       $(brew --prefix mcgrid)/examples-rivet-2.2.0
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/mcgrid.rb
+++ b/Formula/mcgrid.rb
@@ -4,10 +4,10 @@ class Mcgrid < Formula
   url "http://www.hepforge.org/archive/mcgrid/mcgrid-2.0.2.tar.gz"
   sha256 "deed9f6027b075a4d0e2128adb2c13b16ca5736c43426d9a85ac2dfc4f1788d7"
 
+  depends_on "pkg-config" => :build
   depends_on "rivet"
   depends_on "applgrid" => :recommended
   depends_on "fastnlo" => :recommended
-  depends_on "pkg-config" => :build
 
   resource "examples-rivet220" do
     url "http://www.hepforge.org/archive/mcgrid/MCgrid2Examples-2.2.0.tar.gz"

--- a/Formula/nlojet++.rb
+++ b/Formula/nlojet++.rb
@@ -1,7 +1,7 @@
 class Nlojetxx < Formula
   desc "LO and NLO cross sections"
-  homepage "http://www.desy.de/~znagy/Site/NLOJet++.html"
-  url "http://desy.de/~znagy/hep-programs/nlojet++/nlojet++-4.1.3.tar.gz"
+  homepage "https://www.desy.de/~znagy/Site/NLOJet++.html"
+  url "https://desy.de/~znagy/hep-programs/nlojet++/nlojet++-4.1.3.tar.gz"
   sha256 "176d081bbc8c167cdd4516959cbcb2b9ba8f5515f503d29380deee2f67b10ea3"
 
   patch :p1 do

--- a/Formula/openloops.rb
+++ b/Formula/openloops.rb
@@ -23,7 +23,7 @@ class Openloops < Formula
     bin.install_symlink prefix/"openloops"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     OpenLoops downloads and installs process libraries in its
     own installation path: #{prefix}
 

--- a/Formula/openloops.rb
+++ b/Formula/openloops.rb
@@ -29,7 +29,7 @@ class Openloops < Formula
 
     These process libraries are lost if OpenLoops is uninstalled.
 
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/openloops.rb
+++ b/Formula/openloops.rb
@@ -18,7 +18,7 @@ class Openloops < Formula
   patch :DATA
 
   def install
-    scons
+    system "scons"
     cp_r ".", prefix
     bin.install_symlink prefix/"openloops"
   end

--- a/Formula/openloops.rb
+++ b/Formula/openloops.rb
@@ -12,8 +12,8 @@ class Openloops < Formula
     sha256 "2ff311f8bd08e6f6377e73f7848bc4baffe45cce3b56907bf3aa20efbcbe6431" => :el_capitan
   end
 
-  depends_on "gcc" # for gfortran
   depends_on "scons" => :build
+  depends_on "gcc" # for gfortran
 
   patch :DATA
 

--- a/Formula/pythia.rb
+++ b/Formula/pythia.rb
@@ -5,9 +5,9 @@ class Pythia < Formula
   version "8.230"
   sha256 "332fad0ed4f12e6e0cb5755df0ae175329bc16bfaa2ae472d00994ecc99cd78d"
 
+  depends_on "boost"
   depends_on "hepmc"
   depends_on "lhapdf"
-  depends_on "boost"
 
   def install
     args = %W[

--- a/Formula/pythia.rb
+++ b/Formula/pythia.rb
@@ -1,6 +1,6 @@
 class Pythia < Formula
   desc "Monte Carlo event generator"
-  homepage "https://pythia8.hepforge.org"
+  homepage "http://home.thep.lu.se/~torbjorn/Pythia.html"
   url "http://home.thep.lu.se/~torbjorn/pythia8/pythia8230.tgz"
   version "8.230"
   sha256 "332fad0ed4f12e6e0cb5755df0ae175329bc16bfaa2ae472d00994ecc99cd78d"

--- a/Formula/qcdnum.rb
+++ b/Formula/qcdnum.rb
@@ -8,7 +8,7 @@ class Qcdnum < Formula
   depends_on "gcc" # for gfortran
 
   def install
-    libraries = %W[
+    libraries = %w[
       mbutil
       qcdnum
       zmstf
@@ -27,7 +27,19 @@ class Qcdnum < Formula
   end
 
   test do
-    system "gfortran", "-Wall", "-O", "-fbounds-check", "#{prefix}/testjobs/example.f", "-o", "example.exe", "#{lib}/libhqstf.a", "#{lib}/libzmstf.a", "#{lib}/libqcdnum.a", "#{lib}/libmbutil.a"
+    args = %W[
+      -Wall
+      -O
+      -fbounds-check
+      "#{prefix}/testjobs/example.f"
+      -o
+      example.exe
+      "#{lib}/libhqstf.a"
+      "#{lib}/libzmstf.a"
+      "#{lib}/libqcdnum.a"
+      "#{lib}/libmbutil.a"
+    ]
+    system "gfortran", *args
     system "./example.exe"
 
     ohai "Test program worked fine. Use 'brew test -v qcdnum' to watch it work"

--- a/Formula/qcdnum.rb
+++ b/Formula/qcdnum.rb
@@ -1,8 +1,7 @@
 class Qcdnum < Formula
   desc "Fast PDF evolution"
-  homepage "http://www.nikhef.nl/~h24/qcdnum"
-  url "https://www.hepforge.org/archive/qcdnum/qcdnum-17.00.07.tar.gz"
-  mirror "http://www.nikhef.nl/user/h24/qcdnum-files/download/qcdnum170007.tar.gz"
+  homepage "https://www.nikhef.nl/~h24/qcdnum"
+  url "https://www.nikhef.nl/user/h24/qcdnum-files/download/qcdnum170007.tar.gz"
   sha256 "768a8cd4d2f140f8ee0d1ba886bc72f872b39a69b6ef16f890c1044295ce31af"
 
   depends_on "gcc" # for gfortran
@@ -20,8 +19,8 @@ class Qcdnum < Formula
 
     libraries.each do |libname|
       cd libname do
-        system "gfortran", "-c", "-fPIC", "-Wall", "-O2", "-Iinc", "*/*.f"
-        system "ar", "-r", "#{lib}/lib#{libname}.a", "*.o"
+        system "gfortran -c -fPIC -Wall -O2 -Iinc */*.f"
+        system "ar -r #{lib}/lib#{libname}.a *.o"
       end
     end
   end

--- a/Formula/rivet.rb
+++ b/Formula/rivet.rb
@@ -59,7 +59,7 @@ class Rivet < Formula
     It may now be necessary to rebuild your Rivet analyses.
     In case of problems, check your RIVET_ANALYSIS_PATH for old analyses.
 
-    EOS
+  EOS
   end
 
   test do

--- a/Formula/rivet.rb
+++ b/Formula/rivet.rb
@@ -55,7 +55,7 @@ class Rivet < Formula
     bash_completion.install share/"Rivet/rivet-completion"
   end
 
-  def caveats; <<-EOS.undent
+  def caveats; <<~EOS
     It may now be necessary to rebuild your Rivet analyses.
     In case of problems, check your RIVET_ANALYSIS_PATH for old analyses.
 

--- a/Formula/rivet.rb
+++ b/Formula/rivet.rb
@@ -17,17 +17,17 @@ class Rivet < Formula
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
-    depends_on "libtool" => :build
     depends_on "cython" => :build
+    depends_on "libtool" => :build
   end
 
   option "with-test", "Test during installation"
   option "without-analyses", "Do not build Rivet analyses"
   option "with-unvalidated", "Build and install unvalidated analyses"
 
-  depends_on "hepmc"
   depends_on "fastjet"
   depends_on "gsl"
+  depends_on "hepmc"
   depends_on "yoda"
 
   def install

--- a/Formula/rivet.rb
+++ b/Formula/rivet.rb
@@ -30,8 +30,6 @@ class Rivet < Formula
   depends_on "gsl"
   depends_on "yoda"
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/sherpa.rb
+++ b/Formula/sherpa.rb
@@ -11,26 +11,26 @@ class Sherpa < Formula
     sha256 "9d38a5e2718fb45a092fbb8914135a81e43299cac979ef9ad559f6cc73e6af63" => :el_capitan
   end
 
-  patch :p2 do
-    # resolve ambiguous abs calls
-    url "https://gist.githubusercontent.com/davidchall/988f3a2859d7957539a84c79a07a0c2f/raw/3369f6052dcde40c63391fbb4c0e7dd7cc8b9d7d/ambiguous-abs.patch"
-    sha256 "a66699c49e0bd17af0cdfb37ef271f06ba7c068a74e69c5820abc218ae7f3f72"
-  end
-
   option "with-mpi", "Enable MPI support"
 
   # Requires changes to MCFM code, so cannot use MCFM formula
   option "with-mcfm", "Enable use of MCFM loops"
   depends_on "gnu-sed" => :build if build.with? "mcfm"
 
-  depends_on "hepmc"     => :recommended
-  depends_on "rivet"     => :recommended
-  depends_on "lhapdf"    => :recommended
-  depends_on "fastjet"   => :recommended
-  depends_on "openloops" => :recommended
-  depends_on "root"      => :optional
-  depends_on "open-mpi" if build.with? "mpi"
   depends_on "gcc" # for gfortran
+  depends_on "open-mpi" if build.with? "mpi"
+  depends_on "fastjet"   => :recommended
+  depends_on "hepmc"     => :recommended
+  depends_on "lhapdf"    => :recommended
+  depends_on "openloops" => :recommended
+  depends_on "rivet"     => :recommended
+  depends_on "root"      => :optional
+
+  patch :p2 do
+    # resolve ambiguous abs calls
+    url "https://gist.githubusercontent.com/davidchall/988f3a2859d7957539a84c79a07a0c2f/raw/3369f6052dcde40c63391fbb4c0e7dd7cc8b9d7d/ambiguous-abs.patch"
+    sha256 "a66699c49e0bd17af0cdfb37ef271f06ba7c068a74e69c5820abc218ae7f3f72"
+  end
 
   def install
     ENV.cxx11 if build.with?("rivet") || build.with?("lhapdf")

--- a/Formula/sherpa.rb
+++ b/Formula/sherpa.rb
@@ -81,7 +81,7 @@ class Sherpa < Formula
   end
 
   test do
-    (testpath/"Run.dat").write <<-EOS.undent
+    (testpath/"Run.dat").write <<~EOS
       (beam){
         BEAM_1 = 2212; BEAM_ENERGY_1 = 7000
         BEAM_2 = 2212; BEAM_ENERGY_2 = 7000

--- a/Formula/sherpa.rb
+++ b/Formula/sherpa.rb
@@ -1,8 +1,8 @@
 class Sherpa < Formula
   desc "Monte Carlo event generator"
   homepage "https://sherpa.hepforge.org"
-  url "https://www.hepforge.org/archive/sherpa/SHERPA-MC-2.2.4.tar.gz"
-  sha256 "5dc8bccc9a242ead06ce1f8838988b7367641d8989466e0f9d6b7e74fa8e80e7"
+  url "https://sherpa.hepforge.org/downloads/?f=SHERPA-MC-2.2.6.tar.gz"
+  sha256 "f114e68ed610ff80b772d5ee50fb1cd129d0219f38f0825cbb80ca1bfe9c4fb1"
 
   bottle do
     root_url "https://dl.bintray.com/davidchall/bottles-hep"
@@ -18,6 +18,7 @@ class Sherpa < Formula
   depends_on "gnu-sed" => :build if build.with? "mcfm"
 
   depends_on "gcc" # for gfortran
+  depends_on "sqlite" # configure script does not work with system sqlite
   depends_on "open-mpi" if build.with? "mpi"
   depends_on "fastjet"   => :recommended
   depends_on "hepmc"     => :recommended
@@ -25,12 +26,6 @@ class Sherpa < Formula
   depends_on "openloops" => :recommended
   depends_on "rivet"     => :recommended
   depends_on "root"      => :optional
-
-  patch :p2 do
-    # resolve ambiguous abs calls
-    url "https://gist.githubusercontent.com/davidchall/988f3a2859d7957539a84c79a07a0c2f/raw/3369f6052dcde40c63391fbb4c0e7dd7cc8b9d7d/ambiguous-abs.patch"
-    sha256 "a66699c49e0bd17af0cdfb37ef271f06ba7c068a74e69c5820abc218ae7f3f72"
-  end
 
   def install
     ENV.cxx11 if build.with?("rivet") || build.with?("lhapdf")
@@ -42,6 +37,7 @@ class Sherpa < Formula
       --enable-analysis
       --enable-gzip
     ]
+    args << "--with-sqlite3=#{Formula["sqlite"].opt_prefix}"
 
     if build.with? "mpi"
       args << "--enable-mpi"

--- a/Formula/sherpa.rb
+++ b/Formula/sherpa.rb
@@ -32,8 +32,6 @@ class Sherpa < Formula
   depends_on "open-mpi" if build.with? "mpi"
   depends_on "gcc" # for gfortran
 
-  needs :cxx11 if build.with?("rivet") || build.with?("lhapdf")
-
   def install
     ENV.cxx11 if build.with?("rivet") || build.with?("lhapdf")
 

--- a/Formula/sherpa.rb
+++ b/Formula/sherpa.rb
@@ -18,8 +18,8 @@ class Sherpa < Formula
   depends_on "gnu-sed" => :build if build.with? "mcfm"
 
   depends_on "gcc" # for gfortran
-  depends_on "sqlite" # configure script does not work with system sqlite
   depends_on "open-mpi" if build.with? "mpi"
+  depends_on "sqlite" # configure script does not work with system sqlite
   depends_on "fastjet"   => :recommended
   depends_on "hepmc"     => :recommended
   depends_on "lhapdf"    => :recommended

--- a/Formula/thepeg.rb
+++ b/Formula/thepeg.rb
@@ -21,12 +21,12 @@ class Thepeg < Formula
 
   option "with-test", "Test during installation"
 
-  depends_on "gsl"
   depends_on "boost"
-  depends_on "hepmc"   => :recommended
-  depends_on "rivet"   => :recommended
-  depends_on "lhapdf"  => :recommended
+  depends_on "gsl"
   depends_on "fastjet" => :recommended
+  depends_on "hepmc"   => :recommended
+  depends_on "lhapdf"  => :recommended
+  depends_on "rivet"   => :recommended
 
   def install
     args = %W[

--- a/Formula/topdrawer.rb
+++ b/Formula/topdrawer.rb
@@ -5,8 +5,8 @@ class Topdrawer < Formula
   version "1.4e"
   sha256 "2a44dffd19e243aa261b4e3cd2b0fe6247ced97ee10e3271f8c7eeae8cb62401"
 
-  depends_on "gcc" => :build
   depends_on "FranklinChen/tap/f2c" => :build
+  depends_on "gcc" => :build
   depends_on "imake" => :build
   depends_on "ugs" => :build
   depends_on :x11

--- a/Formula/topdrawer.rb
+++ b/Formula/topdrawer.rb
@@ -1,6 +1,6 @@
 class Topdrawer < Formula
   desc "SLAC interface for generating physics graphs"
-  homepage "http://www.pa.msu.edu/reference/topdrawer-docs"
+  homepage "https://www.pa.msu.edu/reference/topdrawer-docs"
   url "http://ftp.riken.jp/pub/iris/topdrawer/topdrawer.tar.gz"
   version "1.4e"
   sha256 "2a44dffd19e243aa261b4e3cd2b0fe6247ced97ee10e3271f8c7eeae8cb62401"

--- a/Formula/topdrawer.rb
+++ b/Formula/topdrawer.rb
@@ -6,8 +6,8 @@ class Topdrawer < Formula
   sha256 "2a44dffd19e243aa261b4e3cd2b0fe6247ced97ee10e3271f8c7eeae8cb62401"
 
   depends_on "gcc" => :build
-  depends_on "homebrew/head-only/f2c" => :build
-  depends_on "homebrew/x11/imake" => :build
+  depends_on "FranklinChen/tap/f2c" => :build
+  depends_on "imake" => :build
   depends_on "ugs" => :build
   depends_on :x11
 

--- a/Formula/topdrawer.rb
+++ b/Formula/topdrawer.rb
@@ -5,8 +5,8 @@ class Topdrawer < Formula
   version "1.4e"
   sha256 "2a44dffd19e243aa261b4e3cd2b0fe6247ced97ee10e3271f8c7eeae8cb62401"
 
-  depends_on "homebrew/head-only/f2c" => :build
   depends_on "gcc" => :build
+  depends_on "homebrew/head-only/f2c" => :build
   depends_on "homebrew/x11/imake" => :build
   depends_on "ugs" => :build
   depends_on :x11

--- a/Formula/ugs.rb
+++ b/Formula/ugs.rb
@@ -6,7 +6,7 @@ class Ugs < Formula
   sha256 "27bc46e975917bdf149e9ff6997885ffa24b0b1416bdf82ffaea5246b36e1f83"
 
   depends_on "gcc" => :build
-  depends_on "homebrew/x11/imake" => :build
+  depends_on "imake" => :build
   depends_on :x11
 
   patch :p1 do

--- a/Formula/ugs.rb
+++ b/Formula/ugs.rb
@@ -5,8 +5,8 @@ class Ugs < Formula
   version "2.10e"
   sha256 "27bc46e975917bdf149e9ff6997885ffa24b0b1416bdf82ffaea5246b36e1f83"
 
-  depends_on "homebrew/x11/imake" => :build
   depends_on "gcc" => :build
+  depends_on "homebrew/x11/imake" => :build
   depends_on :x11
 
   patch :p1 do

--- a/Formula/vbfnlo.rb
+++ b/Formula/vbfnlo.rb
@@ -2,7 +2,6 @@ class Vbfnlo < Formula
   desc "Parton-level Monte Carlo for processes with electroweak bosons"
   homepage "https://www.itp.kit.edu/vbfnlo"
   url "https://www.itp.kit.edu/vbfnlo/wiki/lib/exe/fetch.php?media=download:vbfnlo-3.0.0beta3.tgz"
-  version "3.0.0beta3"
   sha256 "bd1fb2e59fc0095bd339fc7a9d2070a078c6ee16f7b74ae5035763eea153cb58"
 
   option "with-kk", "Enable Kaluza-Klein resonances"
@@ -11,7 +10,7 @@ class Vbfnlo < Formula
   depends_on "gcc" # for gfortran
   depends_on "hepmc" => :recommended
   depends_on "lhapdf" => :recommended
-  depends_on "homebrew/science/root6" => :optional
+  depends_on "root" => :optional
 
   if build.with? "kk"
     depends_on "gsl"
@@ -39,7 +38,7 @@ class Vbfnlo < Formula
   end
 
   test do
-    system "vbfnlo"
+    system "#{bin}/vbfnlo"
     ohai "Successfully computed VBF Higgs production cross section"
   end
 end

--- a/Formula/vbfnlo.rb
+++ b/Formula/vbfnlo.rb
@@ -1,8 +1,8 @@
 class Vbfnlo < Formula
   desc "Parton-level Monte Carlo for processes with electroweak bosons"
   homepage "https://www.itp.kit.edu/vbfnlo"
-  url "https://www.itp.kit.edu/vbfnlo/wiki/lib/exe/fetch.php?media=download:vbfnlo-3.0.0beta3.tgz"
-  sha256 "bd1fb2e59fc0095bd339fc7a9d2070a078c6ee16f7b74ae5035763eea153cb58"
+  url "https://www.itp.kit.edu/vbfnlo/wiki/lib/exe/fetch.php?media=download:vbfnlo-3.0.0beta5.tgz"
+  sha256 "d7ce67aa394a6b47da33ede3a0314436414ec12d6c30238622405bdfb76cb544"
 
   option "with-kk", "Enable Kaluza-Klein resonances"
   option "with-spin2", "Enable spin-2 resonances"

--- a/Formula/vincia.rb
+++ b/Formula/vincia.rb
@@ -4,9 +4,9 @@ class Vincia < Formula
   url "https://www.hepforge.org/archive/vincia/vincia-2.2.01.tgz"
   sha256 "ca98d1bb5f73192e01d1e054f3ba9c385df49a1256dc4c932bf40434b6d56d69"
 
-  depends_on "pythia"
   depends_on "wget" => :build
   depends_on "gcc" # for gfortran
+  depends_on "pythia"
 
   def install
     args = %W[

--- a/Formula/whizard.rb
+++ b/Formula/whizard.rb
@@ -29,7 +29,7 @@ class Whizard < Formula
   end
 
   test do
-    (testpath/"ee.sin").write <<-EOS.undent
+    (testpath/"ee.sin").write <<~EOS
     process ee = e1, E1 => e2, E2
     sqrts = 360 GeV
     n_events = 10

--- a/Formula/whizard.rb
+++ b/Formula/whizard.rb
@@ -1,8 +1,8 @@
 class Whizard < Formula
   desc "Monte Carlo event generator"
   homepage "https://whizard.hepforge.org"
-  url "https://www.hepforge.org/archive/whizard/whizard-2.6.0.tar.gz"
-  sha256 "e3fd7abdcfe4349bc84be36302c831e1262aecad9654a6e6e7b0f0436248814b"
+  url "http://whizard.hepforge.org/whizard-2.7.0.tar.gz"
+  sha256 "97a50705a8ba4174206cdc2c9cf0981a4046352e815e1903f124a92bd05eb4a9"
 
   depends_on "gcc" # for gfortran
   depends_on "ocaml"

--- a/Formula/whizard.rb
+++ b/Formula/whizard.rb
@@ -30,11 +30,11 @@ class Whizard < Formula
 
   test do
     (testpath/"ee.sin").write <<~EOS
-    process ee = e1, E1 => e2, E2
-    sqrts = 360 GeV
-    n_events = 10
-    sample_format = lhef
-    simulate (ee)
+      process ee = e1, E1 => e2, E2
+      sqrts = 360 GeV
+      n_events = 10
+      sample_format = lhef
+      simulate (ee)
     EOS
 
     system "#{bin}/whizard", "-r", testpath, "ee.sin"

--- a/Formula/whizard.rb
+++ b/Formula/whizard.rb
@@ -7,8 +7,8 @@ class Whizard < Formula
   depends_on "gcc" # for gfortran
   depends_on "ocaml"
   depends_on "fastjet" => :optional
-  depends_on "hoppet" => :optional
   depends_on "hepmc" => :optional
+  depends_on "hoppet" => :optional
   depends_on "lhapdf" => :optional
 
   def install

--- a/Formula/yoda.rb
+++ b/Formula/yoda.rb
@@ -28,8 +28,6 @@ class Yoda < Formula
   depends_on "numpy" => :optional
   depends_on "homebrew/science/matplotlib" => :optional
 
-  needs :cxx11
-
   def install
     ENV.cxx11
 

--- a/Formula/yoda.rb
+++ b/Formula/yoda.rb
@@ -24,7 +24,6 @@ class Yoda < Formula
 
   option "with-test", "Test during installation"
 
-  depends_on "homebrew/science/matplotlib" => :optional
   depends_on "numpy" => :optional
   depends_on "root" => :optional
 

--- a/Formula/yoda.rb
+++ b/Formula/yoda.rb
@@ -18,15 +18,15 @@ class Yoda < Formula
 
     depends_on "autoconf" => :build
     depends_on "automake" => :build
-    depends_on "libtool" => :build
     depends_on "cython" => :build
+    depends_on "libtool" => :build
   end
 
   option "with-test", "Test during installation"
 
-  depends_on "root" => :optional
-  depends_on "numpy" => :optional
   depends_on "homebrew/science/matplotlib" => :optional
+  depends_on "numpy" => :optional
+  depends_on "root" => :optional
 
   def install
     ENV.cxx11


### PR DESCRIPTION
Fixes #145.

### Have you:

- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
Yes, that was the initial purpose of opening this PS. Some audit errors remain but they are not critical and I do not know how to fix them without breaking the formula.
- [x] Built your formula locally prior to submission with `brew install <formula>`?
Yes, most formulae install fine again on my machine. In some cases I had to bump the version to achieve this. The only exceptions are vbfnlo and topdrawer, which still have compilation errors. We can address this through a separate issue/PR. Note that I have not run tests nor have I tried any options defined in the formulae.

### Further comments/conclusion

The initial hope of this PR was that the audit fixes make Travis run its checks again without complaining (hence the title). I gave up on this for now after trying a few things (using more recent macOS images and/or other brew test-bot taps). Those attempts fixed some initial errors, but the pipeline never succeeded. I think we need to pull some fixes from @maelvalais' test-bot to @davidchall's test-bot, but I have no permissions and I don't know enough about these forks and what they change w/r/t homebrew’s own test-bot (i.e. upstream).

However, I have tested all formulae locally (as described above), and most work (again). So I think we should merge this PR now such that the majority of the formulae work again.