### PR TITLE
Fix MG5AMC version

### DIFF
--- a/Formula/madgraph5_amcatnlo.rb
+++ b/Formula/madgraph5_amcatnlo.rb
@@ -1,8 +1,8 @@
 class Madgraph5Amcatnlo < Formula
   desc "Automated LO and NLO processes matched to parton showers"
   homepage "https://launchpad.net/mg5amcnlo"
-  url "https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.4.tar.gz"
-  sha256 "ec7f13018433888319536adba436012fca4a2ccb715b2f525c7efa5e870e7605"
+  url "https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.5.tar.gz"
+  sha256 "f41d1afa11566d80c867e1bf3d8d135a28e73042d30bd75f28313dee965e0bdb"
 
   bottle :unneeded
 


### PR DESCRIPTION
`2.6.4` path no longer in existence. Bumped up to `2.6.5` and it works!
`brew audit` failed for me with some `ruby` issue.

### Have you:

- [ ] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### Updates to existing formula: have you

- [x] Checked that the tests still pass?
