### PR TITLE
adding apfelxx formula

### DIFF
--- a/Formula/apfelxx.rb
+++ b/Formula/apfelxx.rb
@@ -1,0 +1,18 @@
+class Apfelxx < Formula
+  desc "Object oriented rewriting of the APFEL evolution code"
+  homepage "https://github.com/vbertone/apfelxx"
+  url "https://github.com/vbertone/apfelxx/archive/4.2.0.tar.gz"
+  sha256 "5ad23e786bf185ce4be0672f7931f6a0a817309f8fdea8e8dab6139ed8dd9a9f"
+
+  depends_on "cmake" => :build
+  depends_on "gcc"
+
+  def install
+    system "cmake", ".", *std_cmake_args
+    system "make", "install"
+  end
+
+  test do
+    system "#{bin}/apfelxx-config", "--dlflags"
+  end
+end


### PR DESCRIPTION
Hello, I would like to add a formula for the code APFEL++.
I've tried to follow the procedure but upon giving `brew audit --strict --online apfelxx` I get this funny error message:

Error: GitHub API Error: API rate limit exceeded for 93.35.240.175. (But here's the good news: Authenticated requests get a higher rate limit. Check out the documentation for more details.)
Try again in 13 minutes 11 seconds, or create a personal access token:
  https://github.com/settings/tokens/new?scopes=gist,public_repo&description=Homebrew
echo 'export HOMEBREW_GITHUB_API_TOKEN=your_token_here' >> ~/.profile

Not sure what it means. I'm gonna try again in a few minutes.
As for the test, I just called the configuration script of the code and this seems to work.