### PR TITLE
[Improvement] Added a flag to install MCEG interfaces to hepmc3.2.2  

### DIFF
--- a/Formula/hepmc3.rb
+++ b/Formula/hepmc3.rb
@@ -16,6 +16,7 @@ class Hepmc3 < Formula
     mkdir "../build" do
       args = %W[
         -DCMAKE_INSTALL_PREFIX=#{prefix}
+        -DHEPMC3_INSTALL_INTERFACES=ON
       ]
       args<<"-DHEPMC3_ENABLE_TEST=ON" if build.with? "test"
       args<<"-DHEPMC3_ENABLE_PYTHON=OFF" if build.without? "python"


### PR DESCRIPTION
Hi all,

this PR assures the installation of HepMC3 interfaces (headers) that can be used with MC generators.

Best regards,
Andrii

 `brew install <formula>` works.
The tests still pass.

Tag @ebothmann 

