### PR TITLE
Update the x11 dependency

### DIFF
--- a/Formula/f2c.rb
+++ b/Formula/f2c.rb
@@ -1,0 +1,61 @@
+class F2c < Formula
+  desc "Compiler from Fortran to C"
+  homepage "http://www.netlib.org/f2c/"
+  head "https://netlib.sandia.gov/f2c/libf2c.zip", :using => :nounzip
+  sha256 "ca404070e9ce0a9aaa6a71fc7d5489d014ade952c5d6de7efb88de8e24f2e8e0"
+
+  resource "f2cexecutablesrc" do
+    url "https://netlib.sandia.gov/f2c/src.tgz", :using => :nounzip
+    sha256 "d4847456aa91c74e5e61e2097780ca6ac3b20869fae8864bfa8dcc66f6721d35"
+  end
+
+  resource "f2cman" do
+    url "https://netlib.sandia.gov/f2c/f2c.1t", :using => :nounzip
+  end
+
+
+  def install
+    system "unzip", "libf2c.zip", "-d", "libf2c"
+    # f2c header and libf2c.a
+    cd "libf2c" do
+      system "make", "-f", "makefile.u", "f2c.h"
+      include.install "f2c.h"
+
+      system "make", "-f", "makefile.u"
+      lib.install "libf2c.a"
+    end
+
+    # f2cexecutable
+    resource("f2cexecutablesrc").stage {
+    system "tar", "zxvf", "src.tgz"
+    cd "src" do
+      system "make", "-f", "makefile.u", "f2c"
+      bin.install "f2c"
+    end
+    }
+
+    # f2cman
+    resource("f2cman").stage {
+    man1.install "f2c.1t"
+    }
+
+  end
+
+  test do
+    # check if executable doesn't error out
+    system "#{bin}/f2c", "--version"
+
+    # hello world test
+    (testpath/"test.f").write <<-EOS.undent
+      C comment line
+            program hello
+            print*, 'hello world'
+            stop
+            end
+    EOS
+    system "#{bin}/f2c", "test.f"
+    assert_predicate testpath/"test.c", :exist?
+    system "cc", "-O", "-o", "test", "test.c", "-lf2c"
+    assert_equal " hello world\n", shell_output("#{testpath}/test")
+  end
+end

--- a/Formula/topdrawer.rb
+++ b/Formula/topdrawer.rb
@@ -5,19 +5,19 @@ class Topdrawer < Formula
   version "1.4e"
   sha256 "2a44dffd19e243aa261b4e3cd2b0fe6247ced97ee10e3271f8c7eeae8cb62401"
 
-  depends_on "FranklinChen/tap/f2c" => :build
+  depends_on "f2c" => :build
   depends_on "gcc" => :build
   depends_on "imake" => :build
   depends_on "ugs" => :build
-  depends_on "libx11"
-  depends_on "libxt"
-  depends_on "libxext"
+  depends_on "libice"
   depends_on "libsm"
-  depends_on "libice"  
-  
+  depends_on "libx11"
+  depends_on "libxext"
+  depends_on "libxt"
+
   patch :p1 do
-    url "https://gist.githubusercontent.com/veprbl/80ced2fcd27dddf48d8e/raw/a5d474f7735221424ebcaa0ff03b6c36135b2d5a/topdrawer_OSX_fix.patch"
-    sha256 "e8218390cd185b7a2e0fcdab120ffec3c518ab448154fcc73e928c7e0052080d"
+    url "https://gist.githubusercontent.com/andriish/9e7da86a48fb8930d19eaadfe982a785/raw/5e5a888cc670b5f52378cc7a6c09f6be7cf377f6/patch-topdrawer-1.txt"
+    sha256 "ff0ecaf06cb27daef99edaec786897c8cc53ef01e45388b4b9c0adfe6859f4a0"
   end
 
   env :std

--- a/Formula/topdrawer.rb
+++ b/Formula/topdrawer.rb
@@ -9,8 +9,12 @@ class Topdrawer < Formula
   depends_on "gcc" => :build
   depends_on "imake" => :build
   depends_on "ugs" => :build
-  depends_on :x11
-
+  depends_on "libx11"
+  depends_on "libxt"
+  depends_on "libxext"
+  depends_on "libsm"
+  depends_on "libice"  
+  
   patch :p1 do
     url "https://gist.githubusercontent.com/veprbl/80ced2fcd27dddf48d8e/raw/a5d474f7735221424ebcaa0ff03b6c36135b2d5a/topdrawer_OSX_fix.patch"
     sha256 "e8218390cd185b7a2e0fcdab120ffec3c518ab448154fcc73e928c7e0052080d"

--- a/Formula/ugs.rb
+++ b/Formula/ugs.rb
@@ -7,15 +7,15 @@ class Ugs < Formula
 
   depends_on "gcc" => :build
   depends_on "imake" => :build
-  depends_on "libx11"
-  depends_on "libxt"
-  depends_on "libxext"
+  depends_on "libice"
   depends_on "libsm"
-  depends_on "libice" 
+  depends_on "libx11"
+  depends_on "libxext"
+  depends_on "libxt"
 
   patch :p1 do
-    url "https://gist.githubusercontent.com/veprbl/80ced2fcd27dddf48d8e/raw/38ac4ffeaf60a067b9753d91bafd859a3459a286/ugs_OSX_fix.patch"
-    sha256 "71e9f95cd75561cf7c698da79c6f62902283a30bbf8a2b837dc394baa6762a02"
+    url "https://gist.githubusercontent.com/andriish/4df18144d5992c0d3301e3f0069b9218/raw/e18c51f5657b9ec8c519ed25cba838fc353fc35d/patch-ugs-1.txt"
+    sha256 "3e8915fbeae36d4ade037940bb74a90208c0c9c53472ffe29632b85bb42c9eca"
   end
 
   def install

--- a/Formula/ugs.rb
+++ b/Formula/ugs.rb
@@ -7,7 +7,11 @@ class Ugs < Formula
 
   depends_on "gcc" => :build
   depends_on "imake" => :build
-  depends_on :x11
+  depends_on "libx11"
+  depends_on "libxt"
+  depends_on "libxext"
+  depends_on "libsm"
+  depends_on "libice" 
 
   patch :p1 do
     url "https://gist.githubusercontent.com/veprbl/80ced2fcd27dddf48d8e/raw/38ac4ffeaf60a067b9753d91bafd859a3459a286/ugs_OSX_fix.patch"


### PR DESCRIPTION
Hi, in this MR:
 - bugfixes to topdrawer and ugs so one can compile them with the newest fortran
 - fixed the dependencies  :x11   to lib*, as required in the new homebrew
 - copied the f2c receipt at the used f2c depndency does not build anymore and very likely will not be updated anytime soon

 BEst regards,

Andrii
