### PR TITLE
fix brew deprecation warning

### DIFF
--- a/Formula/madgraph5_amcatnlo.rb
+++ b/Formula/madgraph5_amcatnlo.rb
@@ -1,8 +1,8 @@
 class Madgraph5Amcatnlo < Formula
   desc "Automated LO and NLO processes matched to parton showers"
   homepage "https://launchpad.net/mg5amcnlo"
-  url "https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.5.tar.gz"
-  sha256 "f41d1afa11566d80c867e1bf3d8d135a28e73042d30bd75f28313dee965e0bdb"
+  url "https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.7.tar.gz"
+  sha256 "d4db991a4b2016b7d84bc9e27514757f993916354c253111402c390785de4cb1"
 
   depends_on "fastjet"
   depends_on "gcc" # for gfortran

--- a/Formula/madgraph5_amcatnlo.rb
+++ b/Formula/madgraph5_amcatnlo.rb
@@ -4,8 +4,6 @@ class Madgraph5Amcatnlo < Formula
   url "https://launchpad.net/mg5amcnlo/2.0/2.6.x/+download/MG5_aMC_v2.6.5.tar.gz"
   sha256 "f41d1afa11566d80c867e1bf3d8d135a28e73042d30bd75f28313dee965e0bdb"
 
-  bottle :unneeded
-
   depends_on "fastjet"
   depends_on "gcc" # for gfortran
 


### PR DESCRIPTION
Warning: Calling bottle :unneeded is deprecated! There is no replacement.
Please report this issue to the davidchall/hep tap (not Homebrew/brew or Homebrew/core):
  /usr/local/Homebrew/Library/Taps/davidchall/homebrew-hep/Formula/madgraph5_amcatnlo.rb:7

### Have you:

- [x] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [x] Built your formula locally prior to submission with `brew install <formula>`?

### New formula: have you

- [ ] Written a sensible test? (The best test is to compile and run a sample program.)

### Updates to existing formula: have you

- [x] Checked that the tests still pass?
