### PR TITLE
LHAPDF update

### DIFF
--- a/Formula/lhapdf.rb
+++ b/Formula/lhapdf.rb
@@ -124,3 +124,12 @@ index 4f99959..d4d056e 100644
  
      return True
  
+@@ -270,7 +229,7 @@ The main sub-commands that can be used are:
+         if not hasattr(self, self.mainargs.COMMAND):
+             print("Unrecognized command")
+             ap.print_help()
+-            exit(2)
++            exit(0)
+
+         ## Use dispatch pattern to invoke method with same name:
+         getattr(self, self.mainargs.COMMAND)(otherargs)

--- a/Formula/lhapdf.rb
+++ b/Formula/lhapdf.rb
@@ -1,8 +1,8 @@
 class Lhapdf < Formula
   desc "PDF interpolation and evaluation"
   homepage "https://lhapdf.hepforge.org/"
-  url "https://www.hepforge.org/archive/lhapdf/LHAPDF-6.2.1.tar.gz"
-  sha256 "6d57ced88592bfd0feca4b0b50839110780c3a1cd158091c075a155c5917202e"
+  url "https://www.hepforge.org/archive/lhapdf/LHAPDF-6.4.0.tar.gz"
+  sha256 "7d2f0267e2d65b0ddee048553b342d7c893a6dbabe1e326cad62de0010dd810c"
 
   head do
     url "http://lhapdf.hepforge.org/hg/lhapdf", using: :hg
@@ -49,13 +49,13 @@ class Lhapdf < Formula
   end
 end
 __END__
-diff --git a/bin/lhapdf.in b/bin/lhapdf.in
-index 8687cff..8582e15 100644
---- a/bin/lhapdf.in
-+++ b/bin/lhapdf.in
-@@ -271,53 +271,20 @@ def download_url(source, dest_dir, dryrun=False):
-
-     else: # URL
+diff --git a/bin/lhapdf b/bin/lhapdf
+index 4f99959..d4d056e 100644
+--- a/bin/lhapdf
++++ b/bin/lhapdf
+@@ -104,62 +104,21 @@ def download_url(source, dest_dir, dryrun=False):
+ 
+     else:  # URL
          url = source
 -        try:
 -            import urllib.request as urllib
@@ -63,23 +63,30 @@ index 8687cff..8582e15 100644
 -            import urllib2 as urllib
 -        try:
 -            u = urllib.urlopen(url)
--            file_size = int(u.info().get('Content-Length')[0])
+-            content_length = u.info().get("Content-Length", 0)
+-            if isinstance(content_length, list):
+-                file_size = int(content_length[0]) if content_length else 0
+-            else:
+-                file_size = int(content_length)
 -        except urllib.URLError:
 -            e = sys.exc_info()[1]
--            logging.error('Unable to download %s' % url)
+-            logging.debug("Unable to download %s" % url)
 -            return False
 -
 +        import urllib
-         logging.debug('Downloading from %s' % url)
-         logging.debug('Downloading to %s' % dest_filepath)
+         logging.debug("Downloading from %s" % url)
+         logging.debug("Downloading to %s" % dest_filepath)
          if dryrun:
--            logging.info('%s [%s]' % (os.path.basename(url), convertBytes(file_size)))
+-            if file_size:
+-                logging.info("%s [%s]" % (os.path.basename(url), convertBytes(file_size)))
+-            else:
+-                logging.info("%s" % os.path.basename(url))
              return False
--
+ 
          try:
--            dest_file = open(dest_filepath, 'wb')
+-            dest_file = open(dest_filepath, "wb")
 -        except IOError:
--            logging.error('Could not write to %s' % dest_filepath)
+-            logging.error("Could not write to %s" % dest_filepath)
 +            urllib.urlretrieve(url, dest_filepath)
 +        except urllib.URLError:
 +            e = sys.exc_info()[1]
@@ -91,7 +98,7 @@ index 8687cff..8582e15 100644
 -        try:
 -            try:
 -                file_size_dl = 0
--                buffer_size  = 8192
+-                buffer_size = 8192
 -                while True:
 -                    buffer = u.read(buffer_size)
 -                    if not buffer: break
@@ -99,20 +106,21 @@ index 8687cff..8582e15 100644
 -                    file_size_dl += len(buffer)
 -                    dest_file.write(buffer)
 -
--                    status  = chr(13) + '%s: ' % os.path.basename(url)
--                    status += r'%s [%3.1f%%]' % (convertBytes(file_size_dl).rjust(10), file_size_dl * 100. / file_size)
--                    sys.stdout.write(status+' ')
+-                    status = chr(13) + "%s: " % os.path.basename(url)
+-                    status += r"%s" % convertBytes(file_size_dl).rjust(10)
+-                    if file_size:
+-                        status += r"[%3.1f%%]" % (file_size_dl * 100. / file_size)
+-                    sys.stdout.write(status + " ")
 -            except urllib.URLError:
 -                e = sys.exc_info()[1]
--                logging.error('Error during download: ', e.reason)
+-                logging.error("Error during download: ", e.reason)
 -                return False
 -            except KeyboardInterrupt:
--                logging.error('Download halted by user')
+-                logging.error("Download halted by user")
 -                return False
 -        finally:
 -            dest_file.close()
--            print('')
-
+-            print("")
+ 
      return True
-
-
+ 


### PR DESCRIPTION
LHAPDF version bump to 6.4.0. see issue #182 

I tried to update the formula however I could not manage to pass the tests. First of all the lhapdf structure has changed so the patch had to be modified which can be found in the commit history. The installation works well but I get the following errors from the tests:

```
$brew audit --strict --online lhapdf

davidchall/hep/lhapdf:
  * Libraries were compiled with a flat namespace.
    This can cause linker errors due to name collisions, and
    is often due to a bug in detecting the macOS version.
      /opt/homebrew/Cellar/lhapdf/6.4.0/lib/libLHAPDF.dylib
Error: 1 problem in 1 formula detected
```

```
$ brew test lhapdf

==> Testing davidchall/hep/lhapdf
==> /opt/homebrew/Cellar/lhapdf/6.4.0/bin/lhapdf help
Last 15 lines from /Users/jackaraz/Library/Logs/Homebrew/lhapdf/test.01.lhapdf:
  - show:        show metadata details of specified PDF sets
  - update:      download and install a new PDF set index file
  - install|get: download and install new PDF set data files
  - upgrade:     download and install newer replacement PDF set data files where available

positional arguments:
  COMMAND [suboptions]  Subcommand to run

optional arguments:
  -h, --help            show this help message and exit
  --listdir LISTDIR     Directory containing the lhapdf.index list file [default: None]
  --pdfdir PDFDIR       Directory for installation of PDF set data [default: None]
  --source SOURCES      Prepend a path or URL to be used as a source of data files [default: ['/cvmfs/sft.cern.ch/lcg/external/lhapdfsets/current/', 'http://lhapdfsets.web.cern.ch/lhapdfsets/current/']]
  -q, --quiet           Suppress normal messages
  -v, --verbose         Output debug messages
objc[79108]: Class AppleTypeCRetimerRestoreInfoHelper is implemented in both /usr/lib/libauthinstall.dylib (0x2146adeb0) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x10989c4f8). One of the two will be used. Which one is undefined.
objc[79108]: Class AppleTypeCRetimerFirmwareAggregateRequestCreator is implemented in both /usr/lib/libauthinstall.dylib (0x2146adf00) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x10989c548). One of the two will be used. Which one is undefined.
objc[79108]: Class AppleTypeCRetimerFirmwareRequestCreator is implemented in both /usr/lib/libauthinstall.dylib (0x2146adf50) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x10989c598). One of the two will be used. Which one is undefined.
objc[79108]: Class ATCRTRestoreInfoFTABFile is implemented in both /usr/lib/libauthinstall.dylib (0x2146adfa0) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x10989c5e8). One of the two will be used. Which one is undefined.
objc[79108]: Class AppleTypeCRetimerFirmwareCopier is implemented in both /usr/lib/libauthinstall.dylib (0x2146adff0) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x10989c638). One of the two will be used. Which one is undefined.
objc[79108]: Class ATCRTRestoreInfoFTABSubfile is implemented in both /usr/lib/libauthinstall.dylib (0x2146ae040) and /Library/Apple/System/Library/PrivateFrameworks/MobileDevice.framework/Versions/A/MobileDevice (0x10989c688). One of the two will be used. Which one is undefined.
Error: davidchall/hep/lhapdf: failed
An exception occurred within a child process:
  BuildError: Failed executing: /opt/homebrew/Cellar/lhapdf/6.4.0/bin/lhapdf help
/opt/homebrew/Library/Homebrew/formula.rb:2312:in `block in system'
/opt/homebrew/Library/Homebrew/formula.rb:2248:in `open'
/opt/homebrew/Library/Homebrew/formula.rb:2248:in `system'
/opt/homebrew/Library/Taps/davidchall/homebrew-hep/Formula/lhapdf.rb:47:in `block in <class:Lhapdf>'
/opt/homebrew/Library/Homebrew/formula.rb:2112:in `block (3 levels) in run_test'
/opt/homebrew/Library/Homebrew/utils.rb:590:in `with_env'
/opt/homebrew/Library/Homebrew/formula.rb:2111:in `block (2 levels) in run_test'
/opt/homebrew/Library/Homebrew/formula.rb:948:in `with_logging'
/opt/homebrew/Library/Homebrew/formula.rb:2110:in `block in run_test'
/opt/homebrew/Library/Homebrew/mktemp.rb:63:in `block in run'
/opt/homebrew/Library/Homebrew/mktemp.rb:63:in `chdir'
/opt/homebrew/Library/Homebrew/mktemp.rb:63:in `run'
/opt/homebrew/Library/Homebrew/formula.rb:2363:in `mktemp'
/opt/homebrew/Library/Homebrew/formula.rb:2104:in `run_test'
/opt/homebrew/Library/Homebrew/test.rb:43:in `block in <main>'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:93:in `block in timeout'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `block in catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:33:in `catch'
/System/Library/Frameworks/Ruby.framework/Versions/2.6/usr/lib/ruby/2.6.0/timeout.rb:108:in `timeout'
/opt/homebrew/Library/Homebrew/test.rb:48:in `<main>'
```

which I couldn't figure out why. @ebothmann any help would be appreciated.
Thanks