### PR TITLE
mcfm: 10.2.1

### DIFF
--- a/Formula/mcfm.rb
+++ b/Formula/mcfm.rb
@@ -1,70 +1,38 @@
 class Mcfm < Formula
   desc "Monte Carlo for FeMtobarn processes"
   homepage "https://mcfm.fnal.gov"
-  url "https://mcfm.fnal.gov/downloads/MCFM-8.2.tar.gz"
-  sha256 "075e3782d3cbe92539dc2835a7b94b657b0261717166b8911d4e13afdba83bfd"
+  url "https://mcfm.fnal.gov/downloads/MCFM-10.2.1.tar.gz"
+  sha256 "5b97dd90159efcef227420b49e8eb53b7f1ee0af8d5a6bf8595a29c320afe2dc"
+  license "GPL-3.0-or-later"
 
   livecheck do
     url :homepage
     regex(/href=.*?MCFM[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
-  depends_on "gcc@7" # for gfortran
-  depends_on "lhapdf" => :optional
+  depends_on "cmake" => :build
+  depends_on arch: :x86_64 # https://github.com/davidchall/homebrew-hep/issues/203
+  depends_on "gcc"
+  depends_on "lhapdf"
 
-  fails_with gcc: "8" do
-    cause <<~EOS
-      gfortran v.8 fails with "Error: Actual argument contains too few
-      elements for dummy argument 'ff'"
-
-    EOS
-  end
-
-  fails_with :clang do
-    build 1000
-    cause "Needs OpenMP headers that are not available with clang"
-  end
+  # needs gcc >= 7
+  fails_with :clang
+  fails_with gcc: "5"
+  fails_with gcc: "6"
 
   def install
-    system "FC=gfortran-7", "./Install"
+    mkdir "../build" do
+      system "cmake", buildpath, *std_cmake_args, "-Duse_internal_lhapdf=OFF"
+      system "make"
+      system "make", "install"
 
-    if build.with? "lhapdf"
-      inreplace "makefile" do |s|
-        s.change_make_var! "LHAPDFLIB", Formula["lhapdf"].opt_prefix
-        s.change_make_var! "PDFROUTINES", "LHAPDF"
-      end
+      doc.install Dir["Doc/*.pdf"]
     end
-
-    system "FC=gfortran-7", "make"
-    bin.install "Bin/mcfm_omp"
-    pkgshare.install Dir["Bin/*"]
-    doc.install "Doc/mcfm.pdf"
-  end
-
-  def post_install
-    pkgshare.install_symlink "#{Formula["lhapdf"].opt_share}/lhapdf/PDFsets" if build.with? "lhapdf"
-  end
-
-  def caveats
-    <<~EOS
-      Running MCFM requires files found in #{pkgshare}
-
-      If using LHAPDF for PDF sets, the PDF data directory
-      must be symlinked to bin/PDFsets for MCFM to run.
-      The default LHAPDF data path is symlinked by default.
-
-    EOS
   end
 
   test do
-    Dir[pkgshare/"*"].each do |fname|
-      ln_s fname, "."
-    end
-    cp pkgshare/"input.DAT", "test.DAT"
-    inreplace "test.DAT", "-1", "0"
-    system bin/"mcfm_omp", "test.DAT"
+    system bin/"mcfm_omp", share/"input.DAT"
+    system "ls"
     assert_predicate testpath/"W_only_nlo_CT14.NN_80___80___13TeV.top", :exist?
-    ohai "Successfully calculated W production at LO"
-    ohai "Use 'brew test -v mcfm' to view ouput"
   end
 end

--- a/Formula/mcfm.rb
+++ b/Formula/mcfm.rb
@@ -11,7 +11,6 @@ class Mcfm < Formula
   end
 
   depends_on "cmake" => :build
-  depends_on arch: :x86_64 # https://github.com/davidchall/homebrew-hep/issues/203
   depends_on "gcc"
   depends_on "lhapdf"
 
@@ -21,17 +20,28 @@ class Mcfm < Formula
   fails_with gcc: "6"
 
   def install
+    gfortran_lib = Formula["gcc"].opt_lib/"gcc"/Formula["gcc"].version_suffix
+    inreplace "lib/qcdloop-2.0.5/CMakeLists.txt",
+      "target_link_libraries(qcdloop_shared)",
+      "target_link_libraries(qcdloop_shared -L#{gfortran_lib} -lquadmath)"
+    inreplace "lib/qcdloop-2.0.5/CMakeLists.txt",
+      "target_link_libraries(qcdloop_static)",
+      "target_link_libraries(qcdloop_static -L#{gfortran_lib} -lquadmath)"
+
     mkdir "../build" do
       system "cmake", buildpath, *std_cmake_args, "-Duse_internal_lhapdf=OFF"
       system "make"
       system "make", "install"
 
+      bin.install "Bin/mcfm_omp"
+      pkgshare.install Dir["Bin/*"]
       doc.install Dir["Doc/*.pdf"]
     end
   end
 
   test do
-    system bin/"mcfm_omp", share/"input.DAT"
+    download_pdfs(buildpath/"pdf-sets", "CT14nnlo")
+    system bin/"mcfm_omp", pkgshare/"input.ini"
     system "ls"
     assert_predicate testpath/"W_only_nlo_CT14.NN_80___80___13TeV.top", :exist?
   end

--- a/Formula/mcfm.rb
+++ b/Formula/mcfm.rb
@@ -31,7 +31,7 @@ class Mcfm < Formula
       "target_link_libraries(qcdloop_static -L#{gfortran_lib} -lquadmath)"
 
     cd "Bin" do
-      args = %W[
+      args = %w[
         -Duse_internal_lhapdf=OFF
       ]
       args << "-Dwith_vvamp=OFF" if build.without? "vv-nnlo"
@@ -42,7 +42,7 @@ class Mcfm < Formula
     end
 
     bin.install "Bin/mcfm_omp"
-    #pkgshare.install Dir["Bin/*"]
+    # pkgshare.install Dir["Bin/*"]
     doc.install Dir["Doc/*.pdf"]
   end
 

--- a/Formula/mcfm.rb
+++ b/Formula/mcfm.rb
@@ -13,7 +13,7 @@ class Mcfm < Formula
   option "with-nnlo-vv", "Build NNLO diboson processes (slow compilation)"
 
   depends_on "cmake" => :build
-  depends_on "gcc@12" => :build # for gfortran
+  depends_on "gcc@12"
   depends_on "lhapdf" => :optional
 
   fails_with :clang

--- a/Formula/mcfm.rb
+++ b/Formula/mcfm.rb
@@ -10,6 +10,8 @@ class Mcfm < Formula
     regex(/href=.*?MCFM[._-]v?(\d+(?:\.\d+)+)\.t/i)
   end
 
+  option "with-vv-nnlo", "Support NNLO diboson processes (slow compilation)"
+
   depends_on "cmake" => :build
   depends_on "gcc"
   depends_on "lhapdf"
@@ -28,15 +30,20 @@ class Mcfm < Formula
       "target_link_libraries(qcdloop_static)",
       "target_link_libraries(qcdloop_static -L#{gfortran_lib} -lquadmath)"
 
-    mkdir "../build" do
-      system "cmake", buildpath, *std_cmake_args, "-Duse_internal_lhapdf=OFF"
-      system "make"
-      system "make", "install"
+    cd "Bin" do
+      args = %W[
+        -Duse_internal_lhapdf=OFF
+      ]
+      args << "-Dwith_vvamp=OFF" if build.without? "vv-nnlo"
 
-      bin.install "Bin/mcfm_omp"
-      pkgshare.install Dir["Bin/*"]
-      doc.install Dir["Doc/*.pdf"]
+      ENV.deparallelize
+      system "cmake", "..", *args
+      system "make"
     end
+
+    bin.install "Bin/mcfm_omp"
+    #pkgshare.install Dir["Bin/*"]
+    doc.install Dir["Doc/*.pdf"]
   end
 
   test do


### PR DESCRIPTION
Cannot link to lhapdf by default because lhapdf is built using clang and mcfm is built using gcc. User can manually override compiler used by lhapdf formula though.

Unfortunately homebrew gcc-11 compiler fails. I think this is a bug in their custom compiler, but the bug doesn't exist in gcc-12. Hopefully that will become the default gcc soon. 