### PR TITLE
lhapdf: 6.5.3

### DIFF
--- a/Formula/lhapdf.rb
+++ b/Formula/lhapdf.rb
@@ -3,10 +3,9 @@ class Lhapdf < Formula
 
   desc "PDF interpolation and evaluation"
   homepage "https://lhapdf.hepforge.org/"
-  url "https://lhapdf.hepforge.org/downloads/?f=LHAPDF-6.5.1.tar.gz"
-  sha256 "1256419e2227d1a4f93387fe1da805e648351417d3755e8af5a30a35a6a66751"
+  url "https://lhapdf.hepforge.org/downloads/?f=LHAPDF-6.5.3.tar.gz"
+  sha256 "57435cd695e297065d53e69bd29090765c934936b6a975ff8c559766f2230359"
   license "GPL-3.0-or-later"
-  revision 2
 
   livecheck do
     url "https://lhapdf.hepforge.org/downloads"
@@ -29,16 +28,16 @@ class Lhapdf < Formula
     depends_on "libtool" => :build
   end
 
-  depends_on "python@3.9"
+  depends_on "python@3.10"
 
   patch :DATA
 
   def python
-    "python3.9"
+    "python3.10"
   end
 
   def install
-    ENV.prepend_path "PATH", Formula["python@3.9"].opt_libexec/"bin"
+    ENV.prepend_path "PATH", Formula["python@3.10"].opt_libexec/"bin"
     ENV.prepend_create_path "PYTHONPATH", prefix/Language::Python.site_packages(python)
 
     args = %W[
@@ -47,14 +46,9 @@ class Lhapdf < Formula
     ]
 
     system "autoreconf", "-i" if build.head?
-    system "./configure", "--disable-python", *args
+    system "./configure", *args
     system "make"
     system "make", "install"
-
-    system "./configure", "--enable-python", *args
-    cd "wrappers/python" do
-      system python, *Language::Python.setup_install_args(prefix, python)
-    end
 
     rewrite_shebang detected_python_shebang, bin/"lhapdf"
   end
@@ -73,21 +67,30 @@ class Lhapdf < Formula
 
   test do
     system bin/"lhapdf", "--help"
-    system Formula["python@3.9"].opt_bin/python, "-c", "import lhapdf"
+    system Formula["python@3.10"].opt_bin/python, "-c", "import lhapdf"
   end
 end
 
 __END__
-diff --git a/wrappers/python/setup.py.in b/wrappers/python/setup.py.in
-index 21a3d27..5b52590 100644
---- a/wrappers/python/setup.py.in
-+++ b/wrappers/python/setup.py.in
-@@ -22,7 +22,7 @@ libdir = os.path.abspath("@top_builddir@/src/.libs")
- ext = Extension("lhapdf",
-                 ["lhapdf.cpp"],
-                 include_dirs=[incdir_src, incdir_build],
--                extra_compile_args=["-I@prefix@/include"],
-+                extra_compile_args=["-std=c++11", "-I@prefix@/include"],
-                 library_dirs=[libdir],
-                 language="C++",
-                 libraries=["stdc++", "LHAPDF"])
+diff --git a/wrappers/python/build.py.in b/wrappers/python/build.py.in
+index c9d6710..955882f 100644
+--- a/wrappers/python/build.py.in
++++ b/wrappers/python/build.py.in
+@@ -34,7 +34,7 @@ libargs = " ".join("-l{}".format(l) for l in libraries)
+
+ ## Python compile/link args
+ pyargs = "-I" + sysconfig.get_config_var("INCLUDEPY")
+-libpys = [os.path.join(sysconfig.get_config_var(ld), sysconfig.get_config_var("LDLIBRARY")) for ld in ["LIBPL", "LIBDIR"]]
++libpys = glob(os.path.join(sysconfig.get_config_var("LIBDIR"), "libpython*.dylib"))
+ libpy = None
+ for lp in libpys:
+     if os.path.exists(lp):
+@@ -46,7 +46,7 @@ if libpy is None:
+ pyargs += " " + libpy
+ pyargs += " " + sysconfig.get_config_var("LIBS")
+ pyargs += " " + sysconfig.get_config_var("LIBM")
+-pyargs += " " + sysconfig.get_config_var("LINKFORSHARED")
++#pyargs += " " + sysconfig.get_config_var("LINKFORSHARED")
+
+
+ ## Assemble the compile & link command

--- a/Formula/lhapdf.rb
+++ b/Formula/lhapdf.rb
@@ -73,24 +73,31 @@ end
 
 __END__
 diff --git a/wrappers/python/build.py.in b/wrappers/python/build.py.in
-index c9d6710..955882f 100644
+index c9d6710..8c2e633 100644
 --- a/wrappers/python/build.py.in
 +++ b/wrappers/python/build.py.in
-@@ -34,7 +34,7 @@ libargs = " ".join("-l{}".format(l) for l in libraries)
+@@ -34,23 +34,12 @@ libargs = " ".join("-l{}".format(l) for l in libraries)
 
  ## Python compile/link args
  pyargs = "-I" + sysconfig.get_config_var("INCLUDEPY")
 -libpys = [os.path.join(sysconfig.get_config_var(ld), sysconfig.get_config_var("LDLIBRARY")) for ld in ["LIBPL", "LIBDIR"]]
-+libpys = glob(os.path.join(sysconfig.get_config_var("LIBDIR"), "libpython*.dylib"))
- libpy = None
- for lp in libpys:
-     if os.path.exists(lp):
-@@ -46,7 +46,7 @@ if libpy is None:
- pyargs += " " + libpy
+-libpy = None
+-for lp in libpys:
+-    if os.path.exists(lp):
+-        libpy = lp
+-        break
+-if libpy is None:
+-    print("No libpython found in expected location {}, exiting".format(libpy))
+-    sys.exit(1)
+-pyargs += " " + libpy
  pyargs += " " + sysconfig.get_config_var("LIBS")
  pyargs += " " + sysconfig.get_config_var("LIBM")
 -pyargs += " " + sysconfig.get_config_var("LINKFORSHARED")
-+#pyargs += " " + sysconfig.get_config_var("LINKFORSHARED")
 
 
  ## Assemble the compile & link command
+-compile_cmd = "  ".join([os.environ.get("CXX", "g++"), "-shared -fPIC",
++compile_cmd = "  ".join([sysconfig.get_config_var("LDCXXSHARED"), "-std=c++11",
+                          "-o", srcname.replace(".cpp", ".so"),
+                          srcpath, incargs, cmpargs, linkargs, libargs, pyargs])
+ print("Build command =", compile_cmd)


### PR DESCRIPTION
LHAPDF stopped using setup.py and replaced with build.py, which is much more difficult to work with. They use Python config variables directly, and assume certain values that Homebrew doesn't use. I needed to manually overwrite which config variables are used.

This will also be used by yoda in the future (and probably eventually rivet too).
