### PR TITLE
Update GHA workflows

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -7,6 +7,9 @@ jobs:
   pr-pull:
     if: contains(github.event.pull_request.labels.*.name, 'pr-pull')
     runs-on: macos-latest
+    permissions:
+      contents: write
+      pull-requests: write
     steps:
       - name: Set up Homebrew
         uses: Homebrew/actions/setup-homebrew@master

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Cache Homebrew Bundler RubyGems
         id: cache
-        uses: actions/cache@v1
+        uses: actions/cache@v3
         with:
           path: ${{ steps.set-up-homebrew.outputs.gems-path }}
           key: ${{ runner.os }}-rubygems-${{ steps.set-up-homebrew.outputs.gems-hash }}

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -38,7 +38,7 @@ jobs:
 
       - run: brew test-bot --only-tap-syntax
 
-      - run: brew test-bot --only-formulae --root-url=https://ghcr.io/v2/davidchall/hep
+      - run: brew test-bot --only-formulae --skip-dependents --root-url=https://ghcr.io/v2/davidchall/hep
         if: github.event_name == 'pull_request'
 
       - name: Upload bottles as artifact


### PR DESCRIPTION
* Align workflows with latest YAML files generated by `brew tap new`
* Skip dependents in test workflow. This was becoming a major bottleneck to merging PRs, because the Homebrew contract is so unstable (e.g., aMC@NLO starts failing the homebrew audit and this blocks an update to hepmc3).