### PR TITLE
Update applgrid to 1.6.35

### DIFF
--- a/Formula/applgrid.rb
+++ b/Formula/applgrid.rb
@@ -4,7 +4,6 @@ class Applgrid < Formula
   url "https://applgrid.hepforge.org/downloads?f=applgrid-1.6.35.tgz"
   sha256 "5a9706ba9875aa958cc4f57abe467baa1ac4b5f01d07133dca3a0cb738cabf36"
   license "GPL-3.0-only"
-  revision 1
 
   livecheck do
     url "https://applgrid.hepforge.org/downloads"

--- a/Formula/applgrid.rb
+++ b/Formula/applgrid.rb
@@ -1,8 +1,8 @@
 class Applgrid < Formula
   desc "Quickly reproduce NLO calculations with any input PDFs"
   homepage "https://applgrid.hepforge.org"
-  url "https://applgrid.hepforge.org/downloads?f=applgrid-1.6.32.tgz"
-  sha256 "bca2dfbca5652688a45c5604e8ca0e7dac935ddd11198842f272ebbe3c43c505"
+  url "https://applgrid.hepforge.org/downloads?f=applgrid-1.6.35.tgz"
+  sha256 "5a9706ba9875aa958cc4f57abe467baa1ac4b5f01d07133dca3a0cb738cabf36"
   license "GPL-3.0-only"
   revision 1
 


### PR DESCRIPTION
Hi @davidchall ,

I have bumped the applgrid Formula to 1.6.35.

Simone

### Have you:

- [ X] Run `brew audit --strict --online <formula>` (where `<formula>` is the name of the formula you're submitting) and corrected all errors?
- [ X] Built your formula locally prior to submission with `brew install <formula>`?



### Updates to existing formula: have you

- [X ] Checked that the tests still pass?
